### PR TITLE
Fix `setup_tester_chain()`

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -180,7 +180,10 @@ def _execute_and_revert_transaction(chain, transaction, block_number="latest"):
 def _get_vm_for_block_number(chain, block_number, mutable=False):
     block = _get_block_by_number(chain, block_number)
     if mutable and not block.header.is_mutable():
-        block.header.make_mutable()
+        if hasattr(block.header, 'make_mutable'):
+            block.header.make_mutable()
+        else:
+            block.header._mutable = True
     vm = chain.get_vm(header=block.header)
     return vm
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -223,7 +223,7 @@ class PyEVMBackend(object):
     def revert_to_snapshot(self, snapshot):
         block = self.chain.get_block_by_hash(snapshot)
         header = self.chain.create_header_from_parent(block.header)
-        self.chain = type(self.chain)(chaindb=self.chaindb, header=header)
+        self.chain = type(self.chain)(chaindb=self.chain.chaindb, header=header)
 
     def reset_to_genesis(self):
         self.account_keys, self.chain = setup_tester_chain()

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -105,7 +105,7 @@ def get_default_genesis_params():
 
 
 def setup_tester_chain():
-    from evm.vm.flavors import MainnetTesterChain
+    from evm.chains.tester import MainnetTesterChain
     from evm.db import get_db_backend
 
     db = get_db_backend()

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import pkg_resources
 import time
-import warnings
 
 from eth_utils import (
     encode_hex,
@@ -55,7 +54,7 @@ GENESIS_EXTRA_DATA = b''
 GENESIS_INITIAL_ALLOC = {}
 
 
-SUPPORTED_FORKS = {FORK_HOMESTEAD, FORK_DAO, FORK_ANTI_DOS}
+SUPPORTED_FORKS = {FORK_HOMESTEAD, FORK_DAO, FORK_ANTI_DOS, FORK_STATE_CLEANUP}
 
 
 def get_default_account_state():
@@ -235,12 +234,6 @@ class PyEVMBackend(object):
         if fork_name in SUPPORTED_FORKS:
             if fork_block:
                 self.fork_blocks[fork_name] = fork_block
-        elif fork_name == FORK_STATE_CLEANUP:
-            warnings.warn(UserWarning(
-                "Py-EVM does not currently support the SpuriousDragon hard fork."
-            ))
-            # TODO: get EIP160 rules implemented in py-evm
-            self.fork_blocks[fork_name] = fork_block
         else:
             raise UnknownFork("Unknown fork name: {0}".format(fork_name))
         self.chain.configure_forks()

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -107,8 +107,9 @@ def get_default_genesis_params():
 def setup_tester_chain():
     from evm.chains.tester import MainnetTesterChain
     from evm.db import get_db_backend
+    from evm.db.chain import BaseChainDB
 
-    db = get_db_backend()
+    db = BaseChainDB(get_db_backend())
     genesis_params = get_default_genesis_params()
     account_keys = get_default_account_keys()
     genesis_state = generate_genesis_state(account_keys)

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -223,7 +223,7 @@ class PyEVMBackend(object):
     def revert_to_snapshot(self, snapshot):
         block = self.chain.get_block_by_hash(snapshot)
         header = self.chain.create_header_from_parent(block.header)
-        self.chain = type(self.chain)(db=self.chain.db, header=header)
+        self.chain = type(self.chain)(chaindb=self.chaindb, header=header)
 
     def reset_to_genesis(self):
         self.account_keys, self.chain = setup_tester_chain()

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -227,7 +227,7 @@ class PyEVMBackend(object):
         if block.number > 0:
             self.chain.chaindb.set_as_canonical_chain_head(block.header)
             self.chain = self.chain.get_chain_at_block_parent(block)
-            self.mine_blocks()
+            self.chain.import_block(block)
         else:
             self.chain.chaindb.set_as_canonical_chain_head(block.header)
             self.chain = self.chain.from_genesis_header(self.chain.chaindb, block.header)

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -224,8 +224,13 @@ class PyEVMBackend(object):
 
     def revert_to_snapshot(self, snapshot):
         block = self.chain.get_block_by_hash(snapshot)
-        self.chain = self.chain.get_chain_at_block_parent(block)
-        self.chain.import_block(block)
+        if block.number > 0:
+            self.chain.chaindb.set_as_canonical_chain_head(block.header)
+            self.chain = self.chain.get_chain_at_block_parent(block)
+            self.mine_blocks()
+        else:
+            self.chain.chaindb.set_as_canonical_chain_head(block.header)
+            self.chain = self.chain.from_genesis_header(self.chain.chaindb, block.header)
 
     def reset_to_genesis(self):
         self.account_keys, self.chain = setup_tester_chain()

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -224,8 +224,8 @@ class PyEVMBackend(object):
 
     def revert_to_snapshot(self, snapshot):
         block = self.chain.get_block_by_hash(snapshot)
-        header = self.chain.create_header_from_parent(block.header)
-        self.chain = type(self.chain)(chaindb=self.chain.chaindb, header=header)
+        self.chain = self.chain.get_chain_at_block_parent(block)
+        self.chain.import_block(block)
 
     def reset_to_genesis(self):
         self.account_keys, self.chain = setup_tester_chain()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             "ethereum>=1.6.0,<2.0.0",
         ],
         'py-evm': [
-            "py-evm==0.2.0a5",
+            "py-evm==0.2.0a7",
         ],
     },
     py_modules=['eth_tester'],

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     coincurve>=6.0.0
     pyethereum16: ethereum>=1.6.0,<1.7.0
     pyethereum20: ethereum>=2.0.0,<2.1.0
-    pyevm: py-evm==0.2.0a5
+    pyevm: py-evm==0.2.0a7
     py27: mock==2.0.0
 basepython =
     py27: python2.7


### PR DESCRIPTION
### What was wrong?
1) The import path of py-evm's `MainnetTesterChain` is wrong.
2) The db generated by `get_db_backend()` is `DB` type, not a `ChainDB`, which has method like `get_state_db()`

### How was it fixed?
1) Correct it to the path of the `MainnetTesterChain` in the latest commit in py-evm master branch.
2) Create a `BaseChainDB` instance from the result of `get_db_backend()`

After fixing these, we can use PyEVMBackend as the backend of `EthereumTester` by
```python
from eth_tester import EthereumTester
from eth_tester.backends.pyevm import PyEVMBackend
t = EthereumTester(PyEVMBackend())
```

#### Cute Animal Picture
![23737663_811656992362037_4674797565630460721_o](https://user-images.githubusercontent.com/8223657/33471249-64b9d446-d6a7-11e7-9e08-4ab9484fd1a9.jpg)


