### PR TITLE
 Match filter prefix against longer topic list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# virtualenv directories
+venv*

--- a/eth_tester/utils/filters.py
+++ b/eth_tester/utils/filters.py
@@ -120,7 +120,7 @@ def check_if_to_block_match(block_number, _type, to_block):
 def check_if_log_matches_flat_topics(log_topics, filter_topics):
     if not filter_topics:
         return True
-    elif len(log_topics) != len(filter_topics):
+    elif len(log_topics) < len(filter_topics):
         return False
     else:
         return all(


### PR DESCRIPTION
### What was wrong?

Filters were overly aggressive. A log with topics `[A, B]` was not matching filter topics `[A]`.

See https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter

eg~

> A transaction with a log with topics [A, B]
will be matched by the following topic filters:
> - `[A]` "A in first position (and anything after)"
> - ...

### How was it fixed?

- Fixed a couple of incorrect tests. Added several new ones.
- Only preemptively reject log topics if they are shorter than the filter topics (previously any mismatch)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/b6/73/e2/b673e2aba5744e2113d6842d39dc9154.jpg)