### PR TITLE
Fix dev dependency that wasn't renamed

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ pytest>=3.2.1,<3.3.0
 tox>=1.8.0
 flake8==3.0.4
 hypothesis>=3.13.0
-ethereum-abi-utils==0.4.0
+eth-abi==0.5.0
 bumpversion==0.5.3


### PR DESCRIPTION
### What was wrong?

`ethereum-abi-utils` was a dev requirement and wasn't updated to the new library name `eth-abi`

### How was it fixed?

Updated it in `requirements-dev.txt`

#### Cute Animal Picture

![edfa1cebf9d316a1da8e478c359f8ef2](https://user-images.githubusercontent.com/824194/34005966-e73130d8-e0b9-11e7-91e5-2a37fadd48a0.jpg)
