### PR TITLE
Allow nonce field for inbound transactions

### DIFF
--- a/eth_tester/backends/mock/factory.py
+++ b/eth_tester/backends/mock/factory.py
@@ -120,6 +120,11 @@ def create_transaction(transaction, block, transaction_index, is_pending, overri
     else:
         yield 'value', transaction.get('value', 0)
 
+    if 'nonce' in overrides:
+        yield 'nonce', overrides['nonce']
+    else:
+        yield 'nonce', transaction.get('nonce', 0)
+
     if 'v' in overrides:
         yield 'v', overrides['v']
     else:

--- a/eth_tester/validation/inbound.py
+++ b/eth_tester/validation/inbound.py
@@ -152,13 +152,16 @@ TRANSACTION_KEYS = {
     'gas_price',
     'value',
     'data',
+    'nonce',
 }
 
-ALLOWED_TRANSACTION_TYPES = {
-    'send',
-    'call',
-    'estimate',
+TRANSACTION_TYPE_INFO = {
+    'send': TRANSACTION_KEYS,
+    'call': TRANSACTION_KEYS.difference({'nonce'}),
+    'estimate': TRANSACTION_KEYS.difference({'nonce'}),
 }
+
+ALLOWED_TRANSACTION_TYPES = set(TRANSACTION_TYPE_INFO.keys())
 
 
 def validate_transaction(value, txn_type):
@@ -167,11 +170,13 @@ def validate_transaction(value, txn_type):
     if not is_dict(value):
         raise ValidationError("Transaction must be a dictionary.  Got: {0}".format(type(value)))
 
-    unknown_keys = tuple(sorted(set(value.keys()).difference(TRANSACTION_KEYS)))
+    unknown_keys = tuple(sorted(set(value.keys()).difference(
+        TRANSACTION_TYPE_INFO[txn_type],
+    )))
     if unknown_keys:
         raise ValidationError(
             "Only the keys '{0}' are allowed.  Got extra keys: '{1}'".format(
-                "/".join(tuple(sorted(TRANSACTION_KEYS))),
+                "/".join(tuple(sorted(TRANSACTION_TYPE_INFO[txn_type]))),
                 "/".join(unknown_keys),
             )
         )
@@ -201,6 +206,8 @@ def validate_transaction(value, txn_type):
         validate_uint256(value['gas_price'])
     if 'value' in value:
         validate_uint256(value['value'])
+    if 'nonce' in value:
+        validate_uint256(value['nonce'])
     if 'data' in value:
         bad_data_message = (
             "Transaction data must be a hexidecimal encoded string.  Got: "

--- a/eth_tester/validation/inbound.py
+++ b/eth_tester/validation/inbound.py
@@ -198,16 +198,24 @@ def validate_transaction(value, txn_type):
 
     if 'from' in value:
         validate_account(value['from'])
+
     if 'to' in value and value['to'] != '':
         validate_account(value['to'])
+    elif 'to' in value and value['to'] == '':
+        validate_text(value['to'])
+
     if 'gas' in value:
         validate_uint256(value['gas'])
+
     if 'gas_price' in value:
         validate_uint256(value['gas_price'])
+
     if 'value' in value:
         validate_uint256(value['value'])
+
     if 'nonce' in value:
         validate_uint256(value['nonce'])
+
     if 'data' in value:
         bad_data_message = (
             "Transaction data must be a hexidecimal encoded string.  Got: "


### PR DESCRIPTION
### What was wrong?

The `nonce` field was not one of the allowed fields for inbound transactions.

### How was it fixed?

Adjusted inbound validators to accept it.

#### Cute Animal Picture

![b31f3ae8ac9f97bfb9f46c3d3667797d](https://user-images.githubusercontent.com/824194/34233243-6e4860b4-e5a1-11e7-8ee7-204bb83bbde8.jpg)
