### PR TITLE
Test Py-EVM backend against python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
     # pyevm
     - python: "3.5"
       env: TOX_POSARGS="-e py35-pyevm"
+    - python: "3.6"
+      env: TOX_POSARGS="-e py36-pyevm"
 cache:
   pip: true
 install:


### PR DESCRIPTION
### What was wrong?

Py-EVM backend was only tested against python3.5

### How was it fixed?

Added 3.6 to the test matrix

#### Cute Animal Picture

![03de49d27ceb531bd2a0d52f9c954f68](https://user-images.githubusercontent.com/824194/34310695-32694b0a-e716-11e7-9972-5e009b3ad61d.jpg)
