### PR TITLE
normalize list of topics with None

### DIFF
--- a/eth_tester/normalization/inbound.py
+++ b/eth_tester/normalization/inbound.py
@@ -33,6 +33,15 @@ def is_32byte_hex_string(value):
 
 
 @to_tuple
+def normalize_topic_list(topics):
+    for topic in topics:
+        if topic is None:
+            yield None
+        else:
+            yield decode_hex(topic)
+
+
+@to_tuple
 def normalize_filter_params(from_block, to_block, address, topics):
     yield from_block
     yield to_block
@@ -53,14 +62,10 @@ def normalize_filter_params(from_block, to_block, address, topics):
     if topics is None:
         yield topics
     elif is_flat_topic_array(topics):
-        yield tuple(
-            decode_hex(item)
-            for item
-            in topics
-        )
+        yield normalize_topic_list(topics)
     elif all(is_flat_topic_array(item) for item in topics):
         yield tuple(
-            tuple(decode_hex(sub_item) for sub_item in item)
+            normalize_topic_list(item)
             for item
             in topics
         )

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -833,6 +833,7 @@ class BaseTestBackendDirect(object):
             [None, 1],
             [[], 1],
             [['0xf70fe689e290d8ce2b2a388ac28db36fbb0e16a6d89c6804c461f65a1b40bb15'], 1],
+            [['0xf70fe689e290d8ce2b2a388ac28db36fbb0e16a6d89c6804c461f65a1b40bb15', None], 1],
             [
                 [
                     '0xf70fe689e290d8ce2b2a388ac28db36fbb0e16a6d89c6804c461f65a1b40bb15',
@@ -852,6 +853,7 @@ class BaseTestBackendDirect(object):
             'filter None',
             'filter []',
             'filter Event only',
+            'filter Event and None',
             'filter Event and argument',
             'filter Event and wrong argument',
         ],


### PR DESCRIPTION
### What was wrong?

eth-tester crashes when creating a filter with a list of topics that includes `None`

It was discovered by trying to swap in eth-tester for eth-testrpc in the web3 test suite: https://github.com/ethereum/web3.py/issues/505

### How was it fixed?

Don't `decode_hex()` on `None` values.

#### Cute Animal Picture

![Cute animal picture](https://46yxb83hlyy77jig73dh02ok-wpengine.netdna-ssl.com/wp-content/uploads/2015/07/Cute-Goats-Photo-28.jpg)