### PR TITLE
Fix pyevm backend 

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -173,9 +173,9 @@ def _get_transaction_by_hash(chain, transaction_hash):
 def _execute_and_revert_transaction(chain, transaction, block_number="latest"):
     vm = _get_vm_for_block_number(chain, block_number, mutable=True)
 
-    snapshot = vm.snapshot()
+    snapshot = vm.state.snapshot()
     computation = vm.execute_transaction(transaction)
-    vm.revert(snapshot)
+    vm.state.revert(snapshot)
     return computation
 
 
@@ -330,17 +330,17 @@ class PyEVMBackend(object):
     #
     def get_nonce(self, account, block_number="latest"):
         vm = _get_vm_for_block_number(self.chain, block_number)
-        with vm.state_db(read_only=True) as state_db:
+        with vm.state.state_db(read_only=True) as state_db:
             return state_db.get_nonce(account)
 
     def get_balance(self, account, block_number="latest"):
         vm = _get_vm_for_block_number(self.chain, block_number)
-        with vm.state_db(read_only=True) as state_db:
+        with vm.state.state_db(read_only=True) as state_db:
             return state_db.get_balance(account)
 
     def get_code(self, account, block_number="latest"):
         vm = _get_vm_for_block_number(self.chain, block_number)
-        with vm.state_db(read_only=True) as state_db:
+        with vm.state.state_db(read_only=True) as state_db:
             return state_db.get_code(account)
 
     #

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm>=0.2.0a7,<0.3.0",
+            "py-evm>=0.2.0a8,<0.3.0",
         ],
     },
     py_modules=['eth_tester'],

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     coincurve>=6.0.0
     pyethereum16: ethereum>=1.6.0,<1.7.0
     pyethereum21: ethereum>=2.1.0,<2.2.0
-    pyevm: py-evm==0.2.0a7
+    pyevm: py-evm==0.2.0a8
     py27: mock==2.0.0
 basepython =
     py27: python2.7


### PR DESCRIPTION
### What was wrong?
Due to the modification of VM class in PyEVM, the structure has changed and some attribute is no longer under `VM`. So any access to those attributes like `PyEVMBackend.get_nonce()` doing will fail.

### How was it fixed?
Change some usage of `vm.xxx` to `vm.state.xxx`

#### Cute Animal Picture

![Cute animal picture](https://scontent-tpe1-1.xx.fbcdn.net/v/t1.0-9/26219939_846570172204052_628252791147457688_n.jpg?oh=9131bfb3ebcfae6f27a74b45d0ab9cc6&oe=5AE93B1B)
