### PR TITLE
make `gas` field optional when estimating gas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ fabric.properties
 
 # virtualenv directories
 venv*
+
+# VIM
+*.swp

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -5,6 +5,7 @@ import pytest
 from cytoolz.dicttoolz import (
     merge,
     assoc,
+    dissoc,
 )
 from hypothesis import (
     strategies as st,
@@ -473,7 +474,7 @@ class BaseTestBackendDirect(object):
             math_address,
             'increment',
         )
-        gas_estimation = eth_tester.estimate_gas(estimate_call_math_transaction)
+        gas_estimation = eth_tester.estimate_gas(dissoc(estimate_call_math_transaction, 'gas'))
         call_math_transaction = assoc(estimate_call_math_transaction, 'gas', gas_estimation)
         transaction_hash = eth_tester.send_transaction(call_math_transaction)
         receipt = eth_tester.get_transaction_receipt(transaction_hash)


### PR DESCRIPTION
### What was wrong?

It is surprising to require a `gas` field when estimating the amount of gas required.

### How was it fixed?

- Modify the test to try a transaction without gas specified
- (in py-evm) Estimate gas by supplying all available gas in the block, and ignore the specified gas
- Run estimate against pending block instead of latest block, to make sure plenty of gas left in block
- Add a bit of wiggle-room to the estimate (it was too restrictive and causing OOG errors on some web3 tests)
- Enforce a minimum estimate, some scenarios were returning 0 gas used (I guess a failure?)

#### Cute Animal Picture

![Cute animal picture](http://english.cri.cn/mmsource/images/2013/01/30/1307otter1301302.jpg)
