### PR TITLE
Catch py-evm BlockNotFound, reraise as eth-tester BlockNotFound

### DIFF
--- a/eth_tester/backends/pyethereum/v20/main.py
+++ b/eth_tester/backends/pyethereum/v20/main.py
@@ -73,7 +73,7 @@ def _get_block_by_number(evm, block_number):
 
 def _get_block_by_hash(evm, block_hash):
     block_by_hash = evm.chain.get_block(block_hash)
-    if block_by_hash.number == evm.block.number:
+    if block_by_hash is None or block_by_hash.number == evm.block.number:
         raise BlockNotFound(
             "Block with hash {0} not found on chain".format(block_hash)
         )

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -45,6 +45,7 @@ from eth_tester.constants import (
 )
 from eth_tester.exceptions import (
     AccountLocked,
+    BlockNotFound,
     FilterNotFound,
     ValidationError,
 )
@@ -408,6 +409,10 @@ class BaseTestBackendDirect(object):
         eth_tester.mine_blocks(10)
         block = eth_tester.get_block_by_number('pending')
         assert block['number'] == 10 + origin_block_number
+
+    def test_get_block_missing(self, eth_tester):
+        with pytest.raises(BlockNotFound):
+            eth_tester.get_block_by_hash('0x' + '00' * 32)
 
     # Transactions
     def test_get_transaction_by_hash(self, eth_tester):

--- a/eth_tester/utils/formatting.py
+++ b/eth_tester/utils/formatting.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import functools
+
 from cytoolz.functoolz import (
     curry,
 )
@@ -71,3 +73,20 @@ def apply_key_map(key_mappings, value):
             yield key_mappings[key], item
         else:
             yield key, item
+
+
+def replace_exceptions(old_to_new_exceptions):
+    old_exceptions = tuple(old_to_new_exceptions.keys())
+
+    def decorator(to_wrap):
+        @functools.wraps(to_wrap)
+        def wrapper(*args, **kwargs):
+            try:
+                return to_wrap(*args, **kwargs)
+            except old_exceptions as e:
+                try:
+                    raise old_to_new_exceptions[type(e)] from e
+                except KeyError:
+                    raise TypeError("could not look up new exception to use for %r" % e) from e
+        return wrapper
+    return decorator


### PR DESCRIPTION
### What was wrong?

eth-tester was raising a py-evm exception that web3 didn't recognize: `BlockNotFound`

### How was it fixed?

catch and re-raise the exception as an eth-tester standard `BlockNotFound`

#### Cute Animal Picture

![Cute animal picture](http://www.animalslook.com/img/cute/cute-sea-otters/cute-sea-otters14.jpg)