### PR TITLE
Allow time-travel in place

### DIFF
--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -145,12 +145,16 @@ class EthereumTester(object):
         self.validator.validate_inbound_timestamp(to_timestamp)
         # make sure we are not traveling back in time as this is not possible.
         current_timestamp = self.get_block_by_number('pending')['timestamp']
-        if to_timestamp <= current_timestamp:
+        if to_timestamp == current_timestamp:
+            # no change, return immediately
+            return
+        elif to_timestamp < current_timestamp:
             raise ValidationError(
                 "Space time continuum distortion detected.  Traveling backwards "
                 "in time violates interdimensional ordinance 31415-926."
             )
-        self.backend.time_travel(to_timestamp)
+        else:
+            self.backend.time_travel(to_timestamp)
 
     #
     # Accounts


### PR DESCRIPTION
### What was wrong?

Calling time travel to a time you're already at disrupted the space-time continuum. It should stay undisturbed.

This caused errors in web3 testing.

### How was it fixed?

If the desired time is exactly the current time, then no further action takes place and no error is raised.

#### Cute Animal Picture

![Cute animal picture](https://media.proprofs.com/images/QM/user_images/1792808/9482059876.jpg)