### PR TITLE
Add `get_logs` for RPC `eth_getLogs`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,15 @@ matrix:
     - python: "3.5"
       env: TOX_POSARGS="-e flake8"
     # core
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34-core"
     - python: "3.5"
       env: TOX_POSARGS="-e py35-core"
     - python: "3.6"
       env: TOX_POSARGS="-e py36-core"
     # pyethereum 1.6.x
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34-pyethereum16"
     - python: "3.5"
       env: TOX_POSARGS="-e py35-pyethereum16"
+    - python: "3.6"
+      env: TOX_POSARGS="-e py36-pyethereum16"
     # pyethereum 2.0.0+
     - python: "3.5"
       env: TOX_POSARGS="-e py35-pyethereum21"

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -627,6 +627,7 @@ class EthereumTester(object):
             topics=topics,
         )
 
+        # Setup the filter object
         raw_filter_params = {
             'from_block': raw_from_block,
             'to_block': raw_to_block,
@@ -637,28 +638,38 @@ class EthereumTester(object):
             check_if_log_matches,
             **raw_filter_params,
         )
-        current_filter = Filter(
+        log_filter = Filter(
             filter_params=raw_filter_params,
             filter_fn=filter_fn,
         )
+        
+        # Set from/to block defaults
         if raw_from_block is None:
             raw_from_block = 'latest'
+        if raw_to_block is None:
+            raw_to_block = 'latest'
+            
+        # Determine lower bound for block range.
         if isinstance(raw_from_block, int):
             lower_bound = raw_from_block
         else:
             lower_bound = self.get_block_by_number(raw_from_block)['number']
-        if raw_to_block is None:
-            raw_to_block = 'latest'
+
+        # Determine upper bound for block range.
         if isinstance(raw_to_block, int):
             upper_bound = raw_to_block
         else:
             upper_bound = self.get_block_by_number(raw_to_block)['number']
+        
+        # Enumerate the blocks in the block range to find all log entries which match.
         for block_number in range(lower_bound, upper_bound + 1):
             block = self.get_block_by_number(block_number)
             for transaction_hash in block['transactions']:
                 receipt = self.get_transaction_receipt(transaction_hash)
                 for log_entry in receipt['logs']:
                     raw_log_entry = self.normalizer.normalize_inbound_log_entry(log_entry)
-                    current_filter.add(raw_log_entry)
-        for item in current_filter.get_all():
+                    log_filter.add(raw_log_entry)
+        
+        # Return the matching log entries
+        for item in log_filter.get_all():
             yield self.normalizer.normalize_outbound_log_entry(item)

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -642,13 +642,13 @@ class EthereumTester(object):
             filter_params=raw_filter_params,
             filter_fn=filter_fn,
         )
-        
+
         # Set from/to block defaults
         if raw_from_block is None:
             raw_from_block = 'latest'
         if raw_to_block is None:
             raw_to_block = 'latest'
-            
+
         # Determine lower bound for block range.
         if isinstance(raw_from_block, int):
             lower_bound = raw_from_block
@@ -660,7 +660,7 @@ class EthereumTester(object):
             upper_bound = raw_to_block
         else:
             upper_bound = self.get_block_by_number(raw_to_block)['number']
-        
+
         # Enumerate the blocks in the block range to find all log entries which match.
         for block_number in range(lower_bound, upper_bound + 1):
             block = self.get_block_by_number(block_number)
@@ -669,7 +669,7 @@ class EthereumTester(object):
                 for log_entry in receipt['logs']:
                     raw_log_entry = self.normalizer.normalize_inbound_log_entry(log_entry)
                     log_filter.add(raw_log_entry)
-        
+
         # Return the matching log entries
         for item in log_filter.get_all():
             yield self.normalizer.normalize_outbound_log_entry(item)

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -608,7 +608,7 @@ class EthereumTester(object):
             yield normalize_fn(item)
 
     @to_tuple
-    def get_logs_directly(self, from_block=None, to_block=None, address=None, topics=None):
+    def get_logs(self, from_block=None, to_block=None, address=None, topics=None):
         self.validator.validate_inbound_filter_params(
             from_block=from_block,
             to_block=to_block,

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -942,7 +942,9 @@ class BaseTestBackendDirect(object):
 
         specific_logs_changes = eth_tester.get_only_filter_changes(filter_event)
         specific_logs_all = eth_tester.get_all_filter_logs(filter_event)
-        assert len(specific_logs_changes) == len(specific_logs_all) == expected
+        specific_direct_logs_all = eth_tester.get_logs_directly(topics=filter_topics)
+        assert len(specific_logs_changes) == len(specific_logs_all) == \
+            len(specific_direct_logs_all) == expected
 
     def test_log_filter_includes_old_logs(self, eth_tester):
         """
@@ -974,7 +976,8 @@ class BaseTestBackendDirect(object):
 
         logs_changes = eth_tester.get_only_filter_changes(filter_any_id)
         logs_all = eth_tester.get_all_filter_logs(filter_any_id)
-        assert len(logs_changes) == len(logs_all) == 2
+        direct_logs_all = eth_tester.get_logs_directly(from_block=0)
+        assert len(logs_changes) == len(logs_all) == len(direct_logs_all) == 2
 
     def test_delete_filter(self, eth_tester):
         self.skip_if_no_evm_execution()

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -942,9 +942,10 @@ class BaseTestBackendDirect(object):
 
         specific_logs_changes = eth_tester.get_only_filter_changes(filter_event)
         specific_logs_all = eth_tester.get_all_filter_logs(filter_event)
-        specific_direct_logs_all = eth_tester.get_logs_directly(topics=filter_topics)
-        assert len(specific_logs_changes) == len(specific_logs_all) == \
-            len(specific_direct_logs_all) == expected
+        specific_direct_logs_all = eth_tester.get_logs(topics=filter_topics)
+        assert len(specific_logs_changes) == expected
+        assert len(specific_logs_all) == expected
+        assert len(specific_direct_logs_all) == expected
 
     def test_log_filter_includes_old_logs(self, eth_tester):
         """
@@ -976,7 +977,7 @@ class BaseTestBackendDirect(object):
 
         logs_changes = eth_tester.get_only_filter_changes(filter_any_id)
         logs_all = eth_tester.get_all_filter_logs(filter_any_id)
-        direct_logs_all = eth_tester.get_logs_directly(from_block=0)
+        direct_logs_all = eth_tester.get_logs(from_block=0)
         assert len(logs_changes) == len(logs_all) == len(direct_logs_all) == 2
 
     def test_delete_filter(self, eth_tester):


### PR DESCRIPTION
### What was wrong?
The corresponding method in `eth_tester` of RPC `eth_getLogs` is not implemented, and it is needed in https://github.com/ethereum/py-evm/pull/265

### How was it fixed?
Implement `get_logs_directly`, which accepts `filter_params` and output the logs directly, without installing filters.


#### Cute Animal Picture

![Cute animal picture](https://scontent-tpe1-1.xx.fbcdn.net/v/t1.0-9/26219757_852240314970371_5344642905383893054_n.jpg?oh=3fd786b2b5b87e148048cd12e12acba8&oe=5AEE6285)
