### PR TITLE
Now compatible with py-evm alpha 9

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -207,7 +207,7 @@ def _get_vm_for_block_number(chain, block_number, mutable=False):
     return vm
 
 
-def _insert_transaction_to_pending(chain, transaction):
+def _insert_transaction_to_pending_block(chain, transaction):
     _, block = chain.get_vm().apply_transaction(transaction)
     chain.header = block.header
 
@@ -405,14 +405,14 @@ class PyEVMBackend(object):
         vm = _get_vm_for_block_number(self.chain, "latest")
         TransactionClass = vm.get_transaction_class()
         evm_transaction = rlp.decode(raw_transaction, TransactionClass)
-        _insert_transaction_to_pending(self.chain, evm_transaction)
+        _insert_transaction_to_pending_block(self.chain, evm_transaction)
         return evm_transaction.hash
 
     def send_transaction(self, transaction):
         signed_evm_transaction = self._get_normalized_and_signed_evm_transaction(
             transaction,
         )
-        _insert_transaction_to_pending(self.chain, signed_evm_transaction)
+        _insert_transaction_to_pending_block(self.chain, signed_evm_transaction)
         return signed_evm_transaction.hash
 
     def _max_available_gas(self):

--- a/eth_tester/backends/pyevm/serializers.py
+++ b/eth_tester/backends/pyevm/serializers.py
@@ -81,8 +81,8 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
     }
 
 
-def serialize_transaction_receipt(block, transaction, transaction_index, is_pending):
-    receipt = block.receipts[transaction_index]
+def serialize_transaction_receipt(block, receipts, transaction, transaction_index, is_pending):
+    receipt = receipts[transaction_index]
 
     if transaction.to == b'':
         contract_addr = to_canonical_address(generate_contract_address(
@@ -95,7 +95,7 @@ def serialize_transaction_receipt(block, transaction, transaction_index, is_pend
     if transaction_index == 0:
         origin_gas = 0
     else:
-        origin_gas = receipt.gas_used - block.receipts[transaction_index - 1].gas_used
+        origin_gas = receipt.gas_used - receipts[transaction_index - 1].gas_used
 
     return {
         "transaction_hash": transaction.hash,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm>=0.2.0a8,<0.3.0",
+            "py-evm>=0.2.0a9,<0.3.0",
         ],
     },
     py_modules=['eth_tester'],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm>=0.2.0a9,<0.3.0",
+            "py-evm==0.2.0a9",  # evm is very high velocity and might change API at each alpha
         ],
     },
     py_modules=['eth_tester'],

--- a/tox.ini
+++ b/tox.ini
@@ -18,13 +18,14 @@ commands=
 deps =
     -r{toxinidir}/requirements-dev.txt
     coincurve>=6.0.0
-    pyethereum16: ethereum>=1.6.0,<1.7.0
-    pyethereum21: ethereum>=2.1.0,<2.2.0
-    pyevm: py-evm==0.2.0a8
 basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+extras =
+    pyevm: py-evm
+    pyethereum16: pyethereum16
+    pyethereum21: pyethereum21
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
### What was wrong?

py-evm's API changed a lot between alpha 8 and 9, breaking eth-tester.

### How was it fixed?

So much `pdbpp`.

Things I found:
- The public API to apply a transaction to the pending block seems to have gone away! I had to manually set the chain header.
- `vm.execute_transaction()` => `state.execute_transaction()`
- `block.receipts` went away

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/fc/05/ee/fc05ee8611ac4a033a73b3836ba9d726--country-living-country-life.jpg)