### PR TITLE
[py-evm] Call with all available gas, if gas is not set

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -422,8 +422,12 @@ class PyEVMBackend(object):
 
     def call(self, transaction, block_number="latest"):
         # TODO: move this to the VM level.
+        defaulted_transaction = transaction.copy()
+        if 'gas' not in defaulted_transaction:
+            defaulted_transaction['gas'] = self._max_available_gas()
+
         signed_evm_transaction = self._get_normalized_and_signed_evm_transaction(
-            transaction,
+            defaulted_transaction,
         )
 
         computation = _execute_and_revert_transaction(self.chain, signed_evm_transaction)


### PR DESCRIPTION
### What was wrong?

`eth_call` without gas was rejected

### How was it fixed?

Default the gas to all gas available in the block.

#### Cute Animal Picture

![Cute animal picture](http://www.clarion-journal.com/.a/6a00d834890c3553ef019b038825a4970d-320wi)
