### PR TITLE
Upgrade to Py-EVM 0.2.0a10 compatible 

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -191,7 +191,7 @@ def _execute_and_revert_transaction(chain, transaction, block_number="latest"):
 
     state = vm.state
     snapshot = state.snapshot()
-    computation, _ = state.execute_transaction(transaction)
+    computation = state.execute_transaction(transaction)
     state.revert(snapshot)
     return computation
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -249,11 +249,11 @@ class PyEVMBackend(object):
     def revert_to_snapshot(self, snapshot):
         block = self.chain.get_block_by_hash(snapshot)
         if block.number > 0:
-            self.chain.chaindb.set_as_canonical_chain_head(block.header)
+            self.chain.chaindb._set_as_canonical_chain_head(block.header)
             self.chain = self.chain.get_chain_at_block_parent(block)
             self.chain.import_block(block)
         else:
-            self.chain.chaindb.set_as_canonical_chain_head(block.header)
+            self.chain.chaindb._set_as_canonical_chain_head(block.header)
             self.chain = self.chain.from_genesis_header(self.chain.chaindb, block.header)
 
     def reset_to_genesis(self):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm==0.2.0a9",  # evm is very high velocity and might change API at each alpha
+            "py-evm==0.2.0a10",  # evm is very high velocity and might change API at each alpha
         ],
     },
     py_modules=['eth_tester'],


### PR DESCRIPTION
### What was wrong?
The interface of Py-EVM is changed, so it's not compatible with the latest Py-EVM.

### How was it fixed?
1. Update `eth_tester.backends.pyevm.main._execute_and_revert_transaction`.
2. Update Py-EVM version.
3. In Py-EVM, `BaseChainDB.set_as_canonical_chain_head` was renamed to `BaseChainDB._set_as_canonical_chain_head`, so I also have to change where `eth-tester` calls this function, but it may look not good to call a protected function of py-evm. Do we need to open an issue for that?


#### Cute Animal Picture

![norway-1758183_1280](https://user-images.githubusercontent.com/9263930/35356268-e2793ed6-018a-11e8-8e1c-3e989265b105.jpg)
