### PR TITLE
upgrade to eth-utils v1, drop unused tox envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
-        "eth-utils>=0.7.1,<1.0.0",
+        "eth-utils>=1.0.0-beta.1,<2.0.0",
         "rlp>=0.6.0,<1.0.0",
         "semantic_version>=2.6.0,<3.0.0",
-        "eth-keys>=0.1.0b3,<0.2.0",
+        "eth-keys>=0.2.0b1,<0.3.0",
     ],
     extras_require={
         'pyethereum16': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{34,35,36}-{core}
-    py{34,35,36}-{pyethereum16,pyethereum21,pyevm}
+    py{35,36}-{core}
+    py{35,36}-{pyethereum16,pyethereum21,pyevm}
     flake8
 
 [flake8]
@@ -19,7 +19,6 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     coincurve>=6.0.0
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
 extras =


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/eth-abi/issues/25 there should be an eth-tester release that supports eth-utils v1.

### How was it fixed?

bump version, everything looks compatible.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/ff/ea/ee/ffeaeeca49265cc12079b6390f645493.jpg)