### PR TITLE
Handle pending transactions

### DIFF
--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -72,15 +72,13 @@ def get_default_fork_blocks():
 def handle_auto_mining(func):
     @functools.wraps(func)
     def func_wrapper(self, *args, **kwargs):
-        if not self.auto_mine_transactions:
-            snapshot = self.take_snapshot()
-
-        transaction_hash = func(self, *args, **kwargs)
-
         if self.auto_mine_transactions:
+            transaction_hash = func(self, *args, **kwargs)
             self.mine_block()
         else:
+            snapshot = self.take_snapshot()
             try:
+                transaction_hash = func(self, *args, **kwargs)
                 pending_transaction = self.get_transaction_by_hash(transaction_hash)
                 # Remove any pending transactions with the same nonce
                 self._pending_transactions = remove_matching_transaction_from_list(
@@ -88,7 +86,6 @@ def handle_auto_mining(func):
                 self._pending_transactions.append(pending_transaction)
             finally:
                 self.revert_to_snapshot(snapshot)
-
         return transaction_hash
     return func_wrapper
 

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -278,13 +278,15 @@ class EthereumTester(object):
         for transaction in self._pending_transactions:
             if transaction['hash'] == transaction_hash:
                 return transaction
+        raise TransactionNotFound(
+            "No transaction found for transaction hash: {0}".format(transaction_hash)
+        )
 
     def get_transaction_by_hash(self, transaction_hash):
         self.validator.validate_inbound_transaction_hash(transaction_hash)
-        pending_transaction = self._get_pending_transaction_by_hash(transaction_hash)
-        if pending_transaction:
-            return pending_transaction
-        else:
+        try:
+            return self._get_pending_transaction_by_hash(transaction_hash)
+        except TransactionNotFound:
             raw_transaction_hash = self.normalizer.normalize_inbound_transaction_hash(
                 transaction_hash,
             )

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -80,7 +80,6 @@ def handle_auto_mining(func):
             self.mine_block()
         else:
             pending_transaction = self.get_transaction_by_hash(transaction_hash)
-            pending_transaction = extract_valid_transaction_params(pending_transaction)
             # Remove any pending transactions with the same nonce
             self._pending_transactions = [tx for tx in self._pending_transactions
                                           if pending_transaction['nonce'] != tx['nonce']]
@@ -314,7 +313,8 @@ class EthereumTester(object):
     #
     def enable_auto_mine_transactions(self):
         self.auto_mine_transactions = True
-        sent_transaction_hashes = [self.send_transaction(tx) for tx in self._pending_transactions]
+        sent_transaction_hashes = [self.send_transaction(extract_valid_transaction_params(tx))
+                                   for tx in self._pending_transactions]
         self._pending_transactions.clear()
         return sent_transaction_hashes
 

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -80,12 +80,14 @@ def handle_auto_mining(func):
         if self.auto_mine_transactions:
             self.mine_block()
         else:
-            pending_transaction = self.get_transaction_by_hash(transaction_hash)
-            # Remove any pending transactions with the same nonce
-            self._pending_transactions = remove_matching_transaction_from_list(
-                self._pending_transactions, pending_transaction)
-            self._pending_transactions.append(pending_transaction)
-            self.revert_to_snapshot(snapshot)
+            try:
+                pending_transaction = self.get_transaction_by_hash(transaction_hash)
+                # Remove any pending transactions with the same nonce
+                self._pending_transactions = remove_matching_transaction_from_list(
+                    self._pending_transactions, pending_transaction)
+                self._pending_transactions.append(pending_transaction)
+            finally:
+                self.revert_to_snapshot(snapshot)
 
         return transaction_hash
     return func_wrapper

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -273,15 +273,25 @@ class EthereumTester(object):
     #
     # Blocks, Transactions, Receipts
     #
+
+    def _get_pending_transaction_by_hash(self, transaction_hash):
+        for transaction in self._pending_transactions:
+            if transaction['hash'] == transaction_hash:
+                return transaction
+
     def get_transaction_by_hash(self, transaction_hash):
         self.validator.validate_inbound_transaction_hash(transaction_hash)
-        raw_transaction_hash = self.normalizer.normalize_inbound_transaction_hash(
-            transaction_hash,
-        )
-        raw_transaction = self.backend.get_transaction_by_hash(raw_transaction_hash)
-        self.validator.validate_outbound_transaction(raw_transaction)
-        transaction = self.normalizer.normalize_outbound_transaction(raw_transaction)
-        return transaction
+        pending_transaction = self._get_pending_transaction_by_hash(transaction_hash)
+        if pending_transaction:
+            return pending_transaction
+        else:
+            raw_transaction_hash = self.normalizer.normalize_inbound_transaction_hash(
+                transaction_hash,
+            )
+            raw_transaction = self.backend.get_transaction_by_hash(raw_transaction_hash)
+            self.validator.validate_outbound_transaction(raw_transaction)
+            transaction = self.normalizer.normalize_outbound_transaction(raw_transaction)
+            return transaction
 
     def get_block_by_number(self, block_number="latest", full_transactions=False):
         self.validator.validate_inbound_block_number(block_number)

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -82,7 +82,8 @@ def handle_auto_mining(func):
             pending_transaction = self.get_transaction_by_hash(transaction_hash)
             # Remove any pending transactions with the same nonce
             self._pending_transactions = [tx for tx in self._pending_transactions
-                                          if pending_transaction['nonce'] != tx['nonce']]
+                                          if not (pending_transaction['nonce'] == tx['nonce']
+                                                  and pending_transaction['from'] == tx['from'])]
             self._pending_transactions.append(pending_transaction)
             self.revert_to_snapshot(snapshot)
 

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -49,6 +49,7 @@ from eth_tester.utils.filters import (
 )
 from eth_tester.utils.transactions import (
     extract_valid_transaction_params,
+    remove_matching_transaction_from_list,
 )
 
 
@@ -81,9 +82,8 @@ def handle_auto_mining(func):
         else:
             pending_transaction = self.get_transaction_by_hash(transaction_hash)
             # Remove any pending transactions with the same nonce
-            self._pending_transactions = [tx for tx in self._pending_transactions
-                                          if not (pending_transaction['nonce'] == tx['nonce']
-                                                  and pending_transaction['from'] == tx['from'])]
+            self._pending_transactions = remove_matching_transaction_from_list(
+                self._pending_transactions, pending_transaction)
             self._pending_transactions.append(pending_transaction)
             self.revert_to_snapshot(snapshot)
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -49,6 +49,7 @@ from eth_tester.exceptions import (
     FilterNotFound,
     ValidationError,
     TransactionFailed,
+    TransactionNotFound,
 )
 from .emitter_contract import (
     _deploy_emitter,
@@ -452,15 +453,15 @@ class BaseTestBackendDirect(object):
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
         assert receipt['transaction_hash'] == transaction_hash
 
-    def test_get_transaction_receipt_for_unmined_transaction(self, eth_tester):
+    def test_get_transaction_receipt_for_unmined_transaction_raises(self, eth_tester):
         eth_tester.disable_auto_mine_transactions()
         transaction_hash = eth_tester.send_transaction({
             "from": eth_tester.get_accounts()[0],
             "to": BURN_ADDRESS,
             "gas": 21000,
         })
-        receipt = eth_tester.get_transaction_receipt(transaction_hash)
-        assert receipt['block_number'] is None
+        with pytest.raises(TransactionNotFound):
+            eth_tester.get_transaction_receipt(transaction_hash)
 
     def test_call_return13(self, eth_tester):
         self.skip_if_no_evm_execution()

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -366,6 +366,36 @@ class BaseTestBackendDirect(object):
         with pytest.raises(TransactionNotFound):
             eth_tester.get_transaction_by_hash(tx2)
 
+    def test_auto_mine_transactions_disabled_returns_hashes_when_enabled(self, eth_tester):
+        self.skip_if_no_evm_execution()
+        eth_tester.mine_blocks()
+        eth_tester.disable_auto_mine_transactions()
+
+        tx1 = eth_tester.send_transaction({
+            "from": eth_tester.get_accounts()[0],
+            "to": BURN_ADDRESS,
+            "value": 1,
+            "gas": 21000,
+            "nonce": 0,
+        })
+        tx2 = eth_tester.send_transaction({  # noqa: F841
+            "from": eth_tester.get_accounts()[1],
+            "to": BURN_ADDRESS,
+            "value": 1,
+            "gas": 21000,
+            "nonce": 0,
+        })
+        tx2_replacement = eth_tester.send_transaction({
+            "from": eth_tester.get_accounts()[1],
+            "to": BURN_ADDRESS,
+            "value": 2,
+            "gas": 21000,
+            "nonce": 0,
+        })
+
+        sent_transactions = eth_tester.enable_auto_mine_transactions()
+        assert sent_transactions == [tx1, tx2_replacement]
+
     #
     # Blocks
     #

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -289,7 +289,7 @@ class BaseTestBackendDirect(object):
 
         self._send_and_check_transaction(eth_tester, test_transaction, accounts[0])
 
-    def test_auto_mine_transactions_enabled(self, eth_tester):
+    def test_block_number_auto_mine_transactions_enabled(self, eth_tester):
         eth_tester.mine_blocks()
         eth_tester.enable_auto_mine_transactions()
         before_block_number = eth_tester.get_block_by_number('latest')['number']
@@ -301,7 +301,7 @@ class BaseTestBackendDirect(object):
         after_block_number = eth_tester.get_block_by_number('latest')['number']
         assert before_block_number == after_block_number - 1
 
-    def test_auto_mine_transactions_disabled(self, eth_tester):
+    def test_auto_mine_transactions_disabled_block_number(self, eth_tester):
         eth_tester.mine_blocks()
         eth_tester.disable_auto_mine_transactions()
         before_block_number = eth_tester.get_block_by_number('latest')['number']
@@ -312,6 +312,23 @@ class BaseTestBackendDirect(object):
         })
         after_block_number = eth_tester.get_block_by_number('latest')['number']
         assert before_block_number == after_block_number
+
+    def test_auto_mine_transactions_disabled_replace_transaction(self, eth_tester):
+        eth_tester.mine_blocks()
+        eth_tester.disable_auto_mine_transactions()
+        transaction = {
+            "from": eth_tester.get_accounts()[0],
+            "to": BURN_ADDRESS,
+            "value": 1,
+            "gas": 21000,
+            "nonce": 0,
+        }
+        try:
+            eth_tester.send_transaction(transaction)
+            transaction["value"] = 2
+            eth_tester.send_transaction(transaction)
+        except Exception:
+            pytest.xfail("Sending replacement transaction caused exception")
 
     #
     # Blocks

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -461,6 +461,17 @@ class BaseTestBackendDirect(object):
         transaction = eth_tester.get_transaction_by_hash(transaction_hash)
         assert transaction['hash'] == transaction_hash
 
+    def test_get_transaction_by_hash_for_unmined_transaction(self, eth_tester):
+        eth_tester.disable_auto_mine_transactions()
+        transaction_hash = eth_tester.send_transaction({
+            "from": eth_tester.get_accounts()[0],
+            "to": BURN_ADDRESS,
+            "gas": 21000,
+        })
+        transaction = eth_tester.get_transaction_by_hash(transaction_hash)
+        assert transaction['hash'] == transaction_hash
+        assert transaction['block_hash'] is None
+
     def test_get_transaction_receipt_for_mined_transaction(self, eth_tester):
         transaction_hash = eth_tester.send_transaction({
             "from": eth_tester.get_accounts()[0],

--- a/eth_tester/utils/transactions.py
+++ b/eth_tester/utils/transactions.py
@@ -1,4 +1,8 @@
 # TODO: Should this be moved to a common package like eth-utils?
+from eth_utils import (
+    to_list,
+)
+
 
 VALID_TRANSACTION_PARAMS = [
     'from',
@@ -15,3 +19,13 @@ VALID_TRANSACTION_PARAMS = [
 def extract_valid_transaction_params(transaction_params):
     return {key: transaction_params[key]
             for key in VALID_TRANSACTION_PARAMS if key in transaction_params}
+
+
+@to_list
+def remove_matching_transaction_from_list(transaction_list, transaction):
+    for tx in transaction_list:
+        nonce_equal = transaction['nonce'] == tx['nonce']
+        from_equal = transaction['from'] == tx['from']
+        match = nonce_equal and from_equal
+        if not match:
+            yield tx

--- a/eth_tester/utils/transactions.py
+++ b/eth_tester/utils/transactions.py
@@ -1,0 +1,17 @@
+# TODO: Should this be moved to a common package like eth-utils?
+
+VALID_TRANSACTION_PARAMS = [
+    'from',
+    'to',
+    'gas',
+    'gasPrice',
+    'value',
+    'data',
+    'nonce',
+    'chainId',
+]
+
+
+def extract_valid_transaction_params(transaction_params):
+    return {key: transaction_params[key]
+            for key in VALID_TRANSACTION_PARAMS if key in transaction_params}

--- a/tests/core/test_transaction_utils.py
+++ b/tests/core/test_transaction_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from eth_tester.utils.transactions import (
+    remove_matching_transaction_from_list,
+)
+
+
+TX1 = {'from': '0x1', 'to': '0x5', 'value': 1, 'nonce': 0}
+TX2 = {'from': '0x2', 'to': '0x5', 'value': 1, 'nonce': 0}
+TX3 = {'from': '0x3', 'to': '0x5', 'value': 1, 'nonce': 0}
+
+
+@pytest.mark.parametrize(
+    'tx_list,transaction,expected',
+    (
+        ([TX1, TX2, TX3], TX2, [TX1, TX3]),
+        ([TX1, TX2, TX3], {'from': '0x2', 'to': '0x6', 'value': 2, 'nonce': 0}, [TX1, TX3])
+    ),
+)
+def test_remove_matching_transaction_from_list(tx_list, transaction, expected):
+    result = remove_matching_transaction_from_list(tx_list, transaction)
+    assert result == expected


### PR DESCRIPTION
### What was wrong?

Eth tester does not handle pending transactions correctly when disabling auto mining transactions:

Sending a transaction with the same nonce causes an invalid nonce error when auto mining transactions are disabled.

The issue is that `send_transaction` and `send_raw_transaction` immediately execute on the vm's state and thereby increment the valid nonce.

### How was it fixed?

Implement a transaction pool at the `eth-tester` level so that transactions are only executed when auto mining is enabled again.

#### Cute Animal Picture

![Cute animal picture](http://www.furrytalk.com/wp-content/uploads/2011/07/Squirrel2.jpg)

Fixes #59 