### PR TITLE
Allow call method to query past state

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -444,7 +444,9 @@ class PyEVMBackend(object):
             block_number,
         )
 
-        computation = _execute_and_revert_transaction(self.chain, signed_evm_transaction, block_number)
+        computation = _execute_and_revert_transaction(self.chain,
+            signed_evm_transaction,
+            block_number)
         if computation.is_error:
             raise TransactionFailed(str(computation._error))
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -444,9 +444,11 @@ class PyEVMBackend(object):
             block_number,
         )
 
-        computation = _execute_and_revert_transaction(self.chain,
+        computation = _execute_and_revert_transaction(
+            self.chain,
             signed_evm_transaction,
-            block_number)
+            block_number,
+        )
         if computation.is_error:
             raise TransactionFailed(str(computation._error))
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -65,7 +65,6 @@ from .throws_contract import (
     _make_call_throws_transaction,
     _decode_throws_result,
 )
-from eth_tester.backends.pyethereum.utils import is_pyethereum16_available
 
 
 PK_A = '0x58d23b55bc9cdce1f18c2500f40ff4ab7245df9a89505e9b1fa4851f623d241d'
@@ -490,7 +489,6 @@ class BaseTestBackendDirect(object):
         result = _decode_math_result('add', raw_result)
         assert result == (20,)
 
-    @pytest.mark.skipif(is_pyethereum16_available(), reason="v1.6 not supported")
     def test_call_query_previous_state(self, eth_tester):
         self.skip_if_no_evm_execution()
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -490,6 +490,8 @@ class BaseTestBackendDirect(object):
         assert result == (20,)
 
     def test_call_query_previous_state(self, eth_tester):
+        self.skip_if_no_evm_execution()
+        
         math_address = _deploy_math(eth_tester)
         call_math_transaction = _make_call_math_transaction(
             eth_tester,

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -65,6 +65,7 @@ from .throws_contract import (
     _make_call_throws_transaction,
     _decode_throws_result,
 )
+from eth_tester.backends.pyethereum.utils import is_pyethereum16_available
 
 
 PK_A = '0x58d23b55bc9cdce1f18c2500f40ff4ab7245df9a89505e9b1fa4851f623d241d'
@@ -489,9 +490,10 @@ class BaseTestBackendDirect(object):
         result = _decode_math_result('add', raw_result)
         assert result == (20,)
 
+    @pytest.mark.skipif(is_pyethereum16_available(), reason="v1.6 not supported")
     def test_call_query_previous_state(self, eth_tester):
         self.skip_if_no_evm_execution()
-        
+
         math_address = _deploy_math(eth_tester)
         call_math_transaction = _make_call_math_transaction(
             eth_tester,

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -489,6 +489,32 @@ class BaseTestBackendDirect(object):
         result = _decode_math_result('add', raw_result)
         assert result == (20,)
 
+    def test_call_query_previous_state(self, eth_tester):
+        math_address = _deploy_math(eth_tester)
+        call_math_transaction = _make_call_math_transaction(
+            eth_tester,
+            math_address,
+            'counter'
+        )
+
+        call_math_transaction_inc = _make_call_math_transaction(
+            eth_tester,
+            math_address,
+            'increment',
+        )
+
+        eth_tester.mine_blocks(2)
+        eth_tester.send_transaction(call_math_transaction_inc)
+
+        raw_result = eth_tester.call(call_math_transaction, 1)
+        result = _decode_math_result('counter', raw_result)
+
+        raw_result_new = eth_tester.call(call_math_transaction)
+        result_new = _decode_math_result('counter', raw_result_new)
+
+        assert result == (0,)
+        assert result_new == (1,)
+
     def test_estimate_gas(self, eth_tester):
         self.skip_if_no_evm_execution()
 

--- a/tests/backends/test_pyethereum16.py
+++ b/tests/backends/test_pyethereum16.py
@@ -34,7 +34,10 @@ def eth_tester():
 
 
 class TestPyEthereum16BackendDirect(BaseTestBackendDirect):
-    pass
+    
+    @pytest.mark.skip(reason="v1.6 not supported")
+    def test_call_query_previous_state(self, eth_tester):
+        pass
 
 
 class TestPyEthereum16BackendFuzz(BaseTestBackendFuzz):


### PR DESCRIPTION

### What was wrong?
In order to implement comprehensive tests for https://github.com/ethereum/web3.py/pull/552 we needed to add functionality to `eth_tester` that allowed one to query past chain state using the `call` method.


### How was it fixed?
A block_number parameter was passed to the `_execute_and_revert_transaction` function and then also passed through to `_get_normalized_and_signed_evm_transaction` function in order to make sure the nonces matched so that the call method's "transaction" could be executed and then reverted.


#### Cute Animal Picture

![Cute animal picture](https://d1bbcn6xx8qu3z.cloudfront.net/sites/default/files/puppy-photo/jordan1-1761550240.jpg)
