### PR TITLE
Carver/pyethereum support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,100 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: lint
+  py35-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-core
+  py36-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core
+  pypy3-core:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-core
+  py35-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-pyevm
+  py36-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-pyevm
+  py35-pyethereum16:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-pyethereum16
+  py36-pyethereum16:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-pyethereum16
+  py35-pyethereum21:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-pyethereum21
+  py36-pyethereum21:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-pyethereum21
+workflows:
+  version: 2
+  test:
+    jobs:
+      - lint
+      - py35-core
+      - py36-core
+      - pypy3-core
+      - py35-pyevm
+      - py36-pyevm
+      - py35-pyethereum16
+      - py36-pyethereum16
+      - py35-pyethereum21
+      - py36-pyethereum21

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ workflows:
       - lint
       - py35-core
       - py36-core
-      - pypy3-core
       - py35-pyevm
       - py36-pyevm
       - py35-pyethereum16

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ matrix:
   include:
     # lint
     - python: "3.5"
-      env: TOX_POSARGS="-e flake8"
+      env: TOX_POSARGS="-e lint"
     # core
     - python: "3.5"
       env: TOX_POSARGS="-e py35-core"
     - python: "3.6"
       env: TOX_POSARGS="-e py36-core"
+    - python: "pypy3.5"
+      env: TOX_POSARGS="-e pypy3-core"
     # pyethereum 1.6.x
     - python: "3.5"
       env: TOX_POSARGS="-e py35-pyethereum16"

--- a/eth_tester/backends/pyethereum/v16/main.py
+++ b/eth_tester/backends/pyethereum/v16/main.py
@@ -14,7 +14,6 @@ import rlp
 
 from eth_utils import (
     encode_hex,
-    remove_0x_prefix,
     to_tuple,
 )
 
@@ -363,15 +362,15 @@ class PyEthereum16Backend(BaseChainBackend):
     #
     def get_nonce(self, account, block_number="latest"):
         block = _get_block_by_number(self.evm, block_number)
-        return block.get_nonce(remove_0x_prefix(account))
+        return block.get_nonce(account)
 
     def get_balance(self, account, block_number="latest"):
         block = _get_block_by_number(self.evm, block_number)
-        return block.get_balance(remove_0x_prefix(account))
+        return block.get_balance(account)
 
     def get_code(self, account, block_number="latest"):
         block = _get_block_by_number(self.evm, block_number)
-        return block.get_code(remove_0x_prefix(account))
+        return block.get_code(account)
 
     #
     # Transactions

--- a/eth_tester/backends/pyethereum/v20/main.py
+++ b/eth_tester/backends/pyethereum/v20/main.py
@@ -10,7 +10,6 @@ import rlp
 
 from eth_utils import (
     is_integer,
-    remove_0x_prefix,
     to_dict,
     to_tuple,
     to_wei,
@@ -377,15 +376,15 @@ class PyEthereum21Backend(BaseChainBackend):
     # NOTE: Added as a helper, might be more broadly useful
     def get_nonce(self, account, block_number="latest"):
         state = _get_state_by_block_number(self.evm, block_number)
-        return state.get_nonce(remove_0x_prefix(account))
+        return state.get_nonce(account)
 
     def get_balance(self, account, block_number="latest"):
         state = _get_state_by_block_number(self.evm, block_number)
-        return state.get_balance(remove_0x_prefix(account))
+        return state.get_balance(account)
 
     def get_code(self, account, block_number="latest"):
         state = _get_state_by_block_number(self.evm, block_number)
-        return state.get_code(remove_0x_prefix(account))
+        return state.get_code(account)
 
     #
     # Transactions

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -123,9 +123,9 @@ def get_default_genesis_params():
 def setup_tester_chain():
     from evm.chains.tester import MainnetTesterChain
     from evm.db import get_db_backend
-    from evm.db.chain import BaseChainDB
+    from evm.db.chain import ChainDB
 
-    db = BaseChainDB(get_db_backend())
+    db = ChainDB(get_db_backend())
     genesis_params = get_default_genesis_params()
     account_keys = get_default_account_keys()
     genesis_state = generate_genesis_state(account_keys)

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -8,7 +8,6 @@ import rlp
 from eth_utils import (
     encode_hex,
     int_to_big_endian,
-    pad_left,
     to_dict,
     to_tuple,
     to_wei,
@@ -89,7 +88,7 @@ def get_default_account_keys():
     keys = KeyAPI()
 
     for i in range(1, 11):
-        pk_bytes = pad_left(int_to_big_endian(i), 32, b'\x00')
+        pk_bytes = int_to_big_endian(i).rjust(32, b'\x00')
         private_key = keys.PrivateKey(pk_bytes)
         yield private_key
 

--- a/eth_tester/backends/pyevm/serializers.py
+++ b/eth_tester/backends/pyevm/serializers.py
@@ -1,11 +1,6 @@
 import rlp
 
-from cytoolz import (
-    partial,
-)
-
 from eth_utils import (
-    pad_left,
     to_canonical_address,
 )
 
@@ -17,7 +12,8 @@ from eth_tester.utils.encoding import (
 )
 
 
-pad32 = partial(pad_left, to_size=32, pad_with=b'\x00')
+def pad32(value):
+    return value.rjust(32, b'\x00')
 
 
 def serialize_block(block, full_transaction, is_pending):

--- a/eth_tester/normalization/inbound.py
+++ b/eth_tester/normalization/inbound.py
@@ -8,11 +8,8 @@ from cytoolz.functoolz import (
 from eth_utils import (
     decode_hex,
     is_address,
-    is_hex,
     is_list_like,
     is_string,
-    is_text,
-    remove_0x_prefix,
     to_canonical_address,
     to_tuple,
 )
@@ -26,10 +23,6 @@ from .common import (
 from eth_tester.validation.inbound import (
     is_flat_topic_array,
 )
-
-
-def is_32byte_hex_string(value):
-    return is_text(value) and is_hex(value) and len(remove_0x_prefix(value)) == 64
 
 
 @to_tuple

--- a/eth_tester/utils/encoding.py
+++ b/eth_tester/utils/encoding.py
@@ -2,17 +2,20 @@ from __future__ import unicode_literals
 
 from cytoolz.functoolz import (
     compose,
-    partial,
+    curry,
 )
 
 from eth_utils import (
     int_to_big_endian,
-    pad_left,
 )
 
 
-zpad = partial(pad_left, pad_with=b'\x00')
-zpad32 = partial(pad_left, to_size=32, pad_with=b'\x00')
+@curry
+def zpad(value, length):
+    return value.rjust(length, b'\x00')
+
+
+zpad32 = zpad(length=32)
 
 
 int_to_32byte_big_endian = compose(

--- a/eth_tester/utils/math_contract.py
+++ b/eth_tester/utils/math_contract.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from eth_utils import (
+    decode_hex,
     encode_hex,
     function_abi_to_4byte_selector,
 )
@@ -144,4 +145,4 @@ def _decode_math_result(fn_name, result):
         in fn_abi['outputs']
     ]
 
-    return decode_abi(output_types, result)
+    return decode_abi(output_types, decode_hex(result))

--- a/eth_tester/utils/secp256k1.py
+++ b/eth_tester/utils/secp256k1.py
@@ -5,7 +5,6 @@ from eth_utils import (
     big_endian_to_int,
     int_to_big_endian,
     is_bytes,
-    pad_left,
 )
 
 from eth_tester.constants import (
@@ -19,7 +18,7 @@ from .jacobian import (
 
 
 def _pad32(value):
-    return pad_left(value, 32, b'\x00')
+    return value.rjust(32, b'\x00')
 
 
 def _encode_raw_public_key(raw_public_key):

--- a/eth_tester/utils/throws_contract.py
+++ b/eth_tester/utils/throws_contract.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from eth_utils import (
+    decode_hex,
     encode_hex,
     function_abi_to_4byte_selector,
 )
@@ -109,4 +110,4 @@ def _decode_throws_result(fn_name, result):
         in fn_abi['outputs']
     ]
 
-    return decode_abi(output_types, result)
+    return decode_abi(output_types, decode_hex(result))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest>=3.2.1,<3.3.0
 tox>=1.8.0
 flake8==3.0.4
 hypothesis>=3.13.0
-eth-abi>=1.0.0-beta.0,<2
+eth-abi>=1.0.0-beta.1,<2
 bumpversion==0.5.3
 eth-hash[pycryptodome]>=0.1.0a2,<1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest>=3.2.1,<3.3.0
 tox>=1.8.0
 flake8==3.0.4
 hypothesis>=3.13.0
-eth-abi==0.5.0
+eth-abi>=1.0.0-beta.0,<2
 bumpversion==0.5.3
 eth-hash[pycryptodome]>=0.1.0a2,<1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flake8==3.0.4
 hypothesis>=3.13.0
 eth-abi==0.5.0
 bumpversion==0.5.3
+eth-hash[pycryptodome]>=0.1.0a2,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
-        "eth-utils>=1.0.0-beta.1,<2.0.0",
+        "eth-utils>=1.0.0-beta.2,<2.0.0",
         "rlp>=0.6.0,<1.0.0",
         "semantic_version>=2.6.0,<3.0.0",
-        "eth-keys>=0.2.0b1,<0.3.0",
+        "eth-keys>=0.2.0-beta.2,<0.3.0",
     ],
     extras_require={
         'pyethereum16': [
@@ -31,7 +31,7 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm==0.2.0a10",  # evm is very high velocity and might change API at each alpha
+            "py-evm==0.2.0a10,<1.0.0",  # evm is very high velocity and might change API at each alpha
         ],
     },
     setup_requires=['setuptools-markdown'],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm==0.2.0a10,<1.0.0",  # evm is very high velocity and might change API at each alpha
+            "py-evm>=0.2.0a11,<1.0.0",  # evm is very high velocity and might change API at each alpha
         ],
     },
     setup_requires=['setuptools-markdown'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{35,36}-{core}
+    py{35,36,py3}-{core}
     py{35,36}-{pyethereum16,pyethereum21,pyevm}
-    flake8
+    lint
 
 [flake8]
 max-line-length= 100
@@ -21,12 +21,13 @@ deps =
 basepython =
     py35: python3.5
     py36: python3.6
+    pypy3: pypy3
 extras =
     pyevm: py-evm
     pyethereum16: pyethereum16
     pyethereum21: pyethereum21
 
-[testenv:flake8]
+[testenv:lint]
 basepython=python
 deps=flake8
 commands=flake8 {toxinidir}/eth_tester


### PR DESCRIPTION
### What was wrong?

A few issues in the pyethereum backend since the eth-utils b2 release.

`remove_0x_prefix` was being called with `bytes` input, and was unnecessary.
`decode_abi` was being called with hexstr input, but only bytes are valid now.

### How was it fixed?

Based on #63 

- remove all prefix calls
- decode hex to bytes before decoding abi
_(It kind of seems like eth-tester should be returning bytes instead of a hexstr, but I don't want to introduce another breaking change in the middle of this cluster)_

#### Cute Animal Picture

![Cute animal picture]()
