### PR TITLE
Manually mine pending transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 eggs
+.eggs
 parts
 bin
 var

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 eth_tester
+	tox -elint
 
 test:
 	py.test tests
@@ -34,7 +34,7 @@ release: clean
 	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true
 	bumpversion $(bump)
-	git push && git push --tags
+	git push upstream && git push upstream --tags
 	python setup.py sdist bdist_wheel upload
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -396,6 +396,27 @@ class BaseTestBackendDirect(object):
         sent_transactions = eth_tester.enable_auto_mine_transactions()
         assert sent_transactions == [tx1, tx2_replacement]
 
+    def test_manual_mine_pending_transactions(self, eth_tester):
+        self.skip_if_no_evm_execution()
+        eth_tester.mine_blocks()
+        eth_tester.disable_auto_mine_transactions()
+
+        txn_hash = eth_tester.send_transaction({
+            "from": eth_tester.get_accounts()[0],
+            "to": BURN_ADDRESS,
+            "value": 1,
+            "gas": 21000,
+            "nonce": 0,
+        })
+
+        with pytest.raises(TransactionNotFound):
+            eth_tester.get_transaction_receipt(txn_hash)
+
+        eth_tester.mine_block()
+
+        receipt = eth_tester.get_transaction_receipt(txn_hash)
+        assert receipt['transaction_hash'] == txn_hash
+
     #
     # Blocks
     #

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,4 @@ extras =
 [testenv:lint]
 basepython=python
 deps=flake8
-commands=flake8 {toxinidir}/eth_tester
+commands=flake8 {toxinidir}/eth_tester {toxinidir}/tests


### PR DESCRIPTION
### What was wrong?

If auto-mine was off, then manually running `mine_block()` was not mining the pending transactions.

### How was it fixed?

- Explicitly check for pending transactions on a `mine_block()` call, and add them to the block
- Plus some refactoring to reduce code duplication. 
- Some config cleanup

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/3f/aa/44/3faa44054abb2df8fd369015bf869831--animal-portraits-colourful-birds.jpg)