### PR TITLE
pin py-evm to exact version, plus comment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
             "ethereum>=2.1.0,<2.2.0",
         ],
         'py-evm': [
-            "py-evm>=0.2.0a11,<1.0.0",  # evm is very high velocity and might change API at each alpha
+            # Pin py-evm to exact version, until it leaves alpha.
+            # EVM is very high velocity and might change API at each alpha.
+            "py-evm==0.2.0a11",
         ],
     },
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
### What was wrong?

py-evm API is still in heavy flux. A new breaking change is about to come through (see https://github.com/ethereum/py-evm/pull/424 )

### How was it fixed?

Pin py-evm to exact version. Upgrade manually and re-run tests at every upgrade.

#### Cute Animal Picture

![Cute animal picture](http://3.bp.blogspot.com/-yAq2e0MbOZw/UF08XUapR1I/AAAAAAAAB2k/-zc66nVAxaE/s1600/beautiful+cute+Apes+monkeys+primates++babiesof+beautiful+dangerous+animals+beautiful+amazing+animal+pictures+by+Pat+SERET.jpg)
