### PR TITLE
Move estimate_gas to vm level in py-evm backend

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -47,7 +47,7 @@ from .utils import is_pyevm_available
 
 if is_pyevm_available():
     from evm.exceptions import (
-        BlockNotFound as EVMBlockNotFound,
+        HeaderNotFound as EVMHeaderNotFound,
         InvalidInstruction as EVMInvalidInstruction,
         Revert as EVMRevert,
     )
@@ -55,7 +55,7 @@ if is_pyevm_available():
         SpoofTransaction as EVMSpoofTransaction
     )
 else:
-    EVMBlockNotFound = None
+    EVMHeaderNotFound = None
     EVMInvalidInstruction = None
     EVMRevert = None
 
@@ -359,13 +359,13 @@ class PyEVMBackend(object):
     #
     # Chain data
     #
-    @replace_exceptions({EVMBlockNotFound: BlockNotFound})
+    @replace_exceptions({EVMHeaderNotFound: BlockNotFound})
     def get_block_by_number(self, block_number, full_transaction=True):
         block = _get_block_by_number(self.chain, block_number)
         is_pending = block.number == self.chain.get_block().number
         return serialize_block(block, full_transaction, is_pending)
 
-    @replace_exceptions({EVMBlockNotFound: BlockNotFound})
+    @replace_exceptions({EVMHeaderNotFound: BlockNotFound})
     def get_block_by_hash(self, block_hash, full_transaction=True):
         block = _get_block_by_hash(self.chain, block_hash)
         is_pending = block.number == self.chain.get_block().number

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -258,7 +258,6 @@ class PyEVMBackend(object):
                 "`PyEVMBackend` requires py-evm to be installed and importable. "
                 "Please install the `py-evm` library."
             )
-
         self.reset_to_genesis()
 
     #
@@ -454,18 +453,10 @@ class PyEVMBackend(object):
         return header.gas_limit - header.gas_used
 
     def estimate_gas(self, transaction):
-        # TODO: move this to the VM level (and use binary search approach)
         signed_evm_transaction = self._get_normalized_and_signed_evm_transaction(
             dict(transaction, gas=self._max_available_gas()),
         )
-
-        computation = _execute_and_revert_transaction(self.chain, signed_evm_transaction, 'pending')
-        if computation.is_error:
-            raise TransactionFailed(str(computation._error))
-
-        gas_used = computation.get_gas_used()
-
-        return int(max(gas_used * GAS_ESTIMATE_BUFFER, MINIMUM_GAS_ESTIMATE))
+        return self.chain.estimate_gas(signed_evm_transaction)
 
     def call(self, transaction, block_number="latest"):
         # TODO: move this to the VM level.

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -51,6 +51,9 @@ if is_pyevm_available():
         InvalidInstruction as EVMInvalidInstruction,
         Revert as EVMRevert,
     )
+    from evm.utils.spoof import (
+        SpoofTransaction as EVMSpoofTransaction
+    )
 else:
     EVMBlockNotFound = None
     EVMInvalidInstruction = None
@@ -467,8 +470,9 @@ class PyEVMBackend(object):
     def estimate_gas(self, transaction):
         evm_transaction = self._get_normalized_and_unsigned_evm_transaction(dict(
             transaction))
+        spoofed_transaction = EVMSpoofTransaction(evm_transaction, from_=transaction['from'])
 
-        return self.chain.estimate_gas(evm_transaction)
+        return self.chain.estimate_gas(spoofed_transaction)
 
     def call(self, transaction, block_number="latest"):
         # TODO: move this to the VM level.

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -465,11 +465,8 @@ class PyEVMBackend(object):
         EVMInvalidInstruction: TransactionFailed,
         EVMRevert: TransactionFailed})
     def estimate_gas(self, transaction):
-        evm_transaction = self._get_normalized_and_unsigned_evm_transaction(
-            dict(
-                transaction,
-                gas=self._max_available_gas(),
-                nonce=0))
+        evm_transaction = self._get_normalized_and_unsigned_evm_transaction(dict(
+            transaction))
 
         return self.chain.estimate_gas(evm_transaction)
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -9,10 +9,6 @@ from cytoolz import (
 
 import rlp
 
-from evm.utils.spoof import (
-    SpoofTransaction
-)
-
 from eth_utils import (
     encode_hex,
     int_to_big_endian,
@@ -463,19 +459,13 @@ class PyEVMBackend(object):
 
     def estimate_gas(self, transaction):
         evm_transaction = self._get_normalized_and_unsigned_evm_transaction(
-            dict(transaction, gas=self._max_available_gas()),
-        )
+            dict(
+                transaction,
+                gas=self._max_available_gas(),
+                nonce=0))
 
-        spoof_evm_transaction = SpoofTransaction(
-            evm_transaction,
-            get_sender=lambda: transaction['from'],
-            sender=transaction['from'],
-            intrinsic_gas=21000,
-            s=1,
-            r=1,
-            v=37)
+        estimate = self.chain.estimate_gas(evm_transaction)
 
-        return self.chain.estimate_gas(spoof_evm_transaction)
 
     def call(self, transaction, block_number="latest"):
         # TODO: move this to the VM level.

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -691,7 +691,11 @@ class BaseTestBackendDirect(object):
         call_math_transaction = assoc(estimate_call_math_transaction, 'gas', gas_estimation)
         transaction_hash = eth_tester.send_transaction(call_math_transaction)
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
-        assert receipt['gas_used'] == gas_estimation
+        assert receipt['gas_used'] <= gas_estimation
+        # Tolerance set to the default py-evm tolerance:
+        # https://github.com/ethereum/py-evm/blob/f0276e684edebd7cd9e84cd04b3229ab9dd958b9/evm/estimators/gas.py#L77
+        # https://github.com/ethereum/py-evm/blob/f0276e684edebd7cd9e84cd04b3229ab9dd958b9/evm/estimators/__init__.py#L11
+        assert receipt['gas_used'] >= gas_estimation - 21000
 
     def test_can_call_after_exception_raised_calling(self, eth_tester):
         self.skip_if_no_evm_execution()

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -728,7 +728,7 @@ class BaseTestBackendDirect(object):
             'willThrow',
         )
         with pytest.raises(TransactionFailed):
-            eth_tester.estimate_gas(dissoc(call_will_throw_transaction, 'gas'))
+            eth_tester.estimate_gas(call_will_throw_transaction)
 
         call_set_value_transaction = _make_call_throws_transaction(
             eth_tester,
@@ -736,7 +736,7 @@ class BaseTestBackendDirect(object):
             'setValue',
             fn_args=(2,),
         )
-        gas_estimation = eth_tester.estimate_gas(dissoc(call_set_value_transaction, 'gas'))
+        gas_estimation = eth_tester.estimate_gas(call_set_value_transaction)
         assert gas_estimation
 
     #

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.2.0a16",
+        "py-evm==0.2.0a17",
     ],
 }
 

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -2,6 +2,10 @@ from __future__ import unicode_literals
 
 import pytest
 
+from cytoolz.dicttoolz import (
+    dissoc,
+)
+
 from eth_tester import (
     EthereumTester,
     PyEVMBackend,
@@ -11,8 +15,23 @@ from eth_tester.backends.pyevm.utils import (
     is_pyevm_available,
 )
 
+from eth_tester.utils.math_contract import (
+    _deploy_math,
+    _make_call_math_transaction,
+    _decode_math_result,
+)
+from eth_tester.utils.throws_contract import (
+    _deploy_throws,
+    _make_call_throws_transaction,
+    _decode_throws_result,
+)
+
 from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
+)
+
+from evm.exceptions import (
+    InvalidInstruction
 )
 
 
@@ -25,4 +44,23 @@ def eth_tester():
 
 
 class TestPyEVMBackendDirect(BaseTestBackendDirect):
-    pass
+    def test_can_estimate_gas_after_exception_raised_estimating_gas(self, eth_tester):
+        self.skip_if_no_evm_execution()
+
+        throws_address = _deploy_throws(eth_tester)
+        call_will_throw_transaction = _make_call_throws_transaction(
+            eth_tester,
+            throws_address,
+            'willThrow',
+        )
+        with pytest.raises(InvalidInstruction):
+            eth_tester.estimate_gas(dissoc(call_will_throw_transaction, 'gas'))
+
+        call_set_value_transaction = _make_call_throws_transaction(
+            eth_tester,
+            throws_address,
+            'setValue',
+            fn_args=(2,),
+        )
+        gas_estimation = eth_tester.estimate_gas(dissoc(call_set_value_transaction, 'gas'))
+        assert gas_estimation

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -2,28 +2,9 @@ from __future__ import unicode_literals
 
 import pytest
 
-from cytoolz.dicttoolz import (
-    dissoc,
-)
-
 from eth_tester import (
     EthereumTester,
     PyEVMBackend,
-)
-
-from eth_tester.backends.pyevm.utils import (
-    is_pyevm_available,
-)
-
-from eth_tester.utils.math_contract import (
-    _deploy_math,
-    _make_call_math_transaction,
-    _decode_math_result,
-)
-from eth_tester.utils.throws_contract import (
-    _deploy_throws,
-    _make_call_throws_transaction,
-    _decode_throws_result,
 )
 
 from eth_tester.utils.backend_testing import (
@@ -40,4 +21,4 @@ def eth_tester():
 
 
 class TestPyEVMBackendDirect(BaseTestBackendDirect):
-        pass
+    pass

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -7,6 +7,9 @@ from eth_tester import (
     PyEVMBackend,
 )
 
+from eth_tester.backends.pyevm.utils import (
+    is_pyevm_available,
+)
 from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
 )

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -30,10 +30,6 @@ from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
 )
 
-from evm.exceptions import (
-    InvalidInstruction
-)
-
 
 @pytest.fixture
 def eth_tester():
@@ -44,23 +40,4 @@ def eth_tester():
 
 
 class TestPyEVMBackendDirect(BaseTestBackendDirect):
-    def test_can_estimate_gas_after_exception_raised_estimating_gas(self, eth_tester):
-        self.skip_if_no_evm_execution()
-
-        throws_address = _deploy_throws(eth_tester)
-        call_will_throw_transaction = _make_call_throws_transaction(
-            eth_tester,
-            throws_address,
-            'willThrow',
-        )
-        with pytest.raises(InvalidInstruction):
-            eth_tester.estimate_gas(dissoc(call_will_throw_transaction, 'gas'))
-
-        call_set_value_transaction = _make_call_throws_transaction(
-            eth_tester,
-            throws_address,
-            'setValue',
-            fn_args=(2,),
-        )
-        gas_estimation = eth_tester.estimate_gas(dissoc(call_set_value_transaction, 'gas'))
-        assert gas_estimation
+        pass


### PR DESCRIPTION
depends on: https://github.com/ethereum/py-evm/pull/432

### What was wrong?

eth-tester implemented `estimate_gas` before py-evm.

### How was it fixed?

This change delegates the py-evm backends `estimate_gas` to py-evm.

#### Cute Animal Picture

![Cute animal picture](https://s-media-cache-ak0.pinimg.com/originals/e9/9b/01/e99b013c50ec924481dbccbdf134d0ee.jpg)
