### PR TITLE
use abc for backend base class

### DIFF
--- a/eth_tester/backends/base.py
+++ b/eth_tester/backends/base.py
@@ -1,84 +1,110 @@
-class BaseChainBackend(object):
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+
+
+class BaseChainBackend(metaclass=ABCMeta):
     #
     # Snapshot API
     #
+    @abstractmethod
     def take_snapshot(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def revert_to_snapshot(self, snapshot):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def reset_to_genesis(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Fork block numbers
     #
+    @abstractmethod
     def set_fork_block(self, fork_name, fork_block):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_fork_block(self, fork_name):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Meta
     #
+    @abstractmethod
     def time_travel(self, to_timestamp):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Mining
     #
+    @abstractmethod
     def mine_blocks(self, num_blocks=1, coinbase=None):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Accounts
     #
+    @abstractmethod
     def get_accounts(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def add_account(self, private_key):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Chain data
     #
+    @abstractmethod
     def get_block_by_number(self, block_number, full_transaction=True):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_block_by_hash(self, block_hash, full_transaction=True):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_transaction_by_hash(self, transaction_hash):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_transaction_receipt(self, transaction_hash):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Account state
     #
+    @abstractmethod
     def get_nonce(self, account, block_number=None):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_balance(self, account, block_number=None):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_code(self, account, block_number=None):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Transactions
     #
+    @abstractmethod
     def send_transaction(self, transaction):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def send_signed_transaction(self, transaction):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def estimate_gas(self, transaction):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def call(self, transaction, block_number="latest"):
         raise NotImplementedError("Must be implemented by subclasses")

--- a/eth_tester/backends/pyethereum/v16/main.py
+++ b/eth_tester/backends/pyethereum/v16/main.py
@@ -399,6 +399,9 @@ class PyEthereum16Backend(BaseChainBackend):
         )
         return self.evm.last_tx.hash
 
+    def send_signed_transaction(self, transaction):
+        raise NotImplementedError("Not implemented in the PyEthereum16Backend backend")
+
     @replace_exceptions({Pyeth16TransactionFailed: TransactionFailed})
     def call(self, transaction, block_number="latest"):
         from ethereum import tester

--- a/eth_tester/backends/pyethereum/v20/main.py
+++ b/eth_tester/backends/pyethereum/v20/main.py
@@ -399,6 +399,9 @@ class PyEthereum21Backend(BaseChainBackend):
         _send_transaction(self.evm, transaction)
         return self.evm.last_tx.hash
 
+    def send_signed_transaction(self, transaction):
+        raise NotImplementedError("Not implemented in the PyEthereum21Backend backend")
+
     @replace_exceptions({Pyeth21TransactionFailed: TransactionFailed})
     def estimate_gas(self, transaction):
         snapshot = self.take_snapshot()


### PR DESCRIPTION
### What was wrong?

The base backend class didn't use the utilities provided by the `abc` module for abstract base classes.

### How was it fixed?

Added the metaclass and the `abstractmethod` decorator to the base backend class.

#### Cute Animal Picture

![flying-cat-1](https://user-images.githubusercontent.com/824194/38205681-ae05395c-3664-11e8-923e-d6d117ebead5.jpg)

