### PR TITLE
remove fuzz tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest>=3.2.1,<4.0.0
 tox>=1.8.0
 flake8==3.0.4
-hypothesis>=3.13.0
 eth-abi>=1.0.0-beta.1,<2
 bumpversion==0.5.3
 eth-hash[pycryptodome]>=0.1.0a2,<1.0.0

--- a/tests/backends/test_pyethereum16.py
+++ b/tests/backends/test_pyethereum16.py
@@ -2,10 +2,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-from hypothesis import (
-    settings,
-)
-
 from eth_tester import (
     EthereumTester,
     PyEthereum16Backend,
@@ -17,8 +13,6 @@ from eth_tester.backends.pyethereum.utils import (
 
 from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
-    BaseTestBackendFuzz,
-    EVMStateFuzzer,
 )
 
 
@@ -34,16 +28,7 @@ def eth_tester():
 
 
 class TestPyEthereum16BackendDirect(BaseTestBackendDirect):
-    
+
     @pytest.mark.skip(reason="v1.6 not supported")
     def test_call_query_previous_state(self, eth_tester):
         pass
-
-
-class TestPyEthereum16BackendFuzz(BaseTestBackendFuzz):
-    pass
-
-
-
-#TestPyEthereum16EVMStateFuzzer = EVMStateFuzzer.TestCase
-#TestPyEthereum16EVMStateFuzzer.settings = settings(max_examples=20, stateful_step_count=50)

--- a/tests/backends/test_pyethereum21.py
+++ b/tests/backends/test_pyethereum21.py
@@ -2,10 +2,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-from hypothesis import (
-    settings,
-)
-
 from eth_tester import (
     EthereumTester,
     PyEthereum21Backend,
@@ -17,8 +13,6 @@ from eth_tester.backends.pyethereum.utils import (
 
 from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
-    BaseTestBackendFuzz,
-    EVMStateFuzzer,
 )
 
 
@@ -35,12 +29,3 @@ def eth_tester():
 
 class TestPyEthereum21BackendDirect(BaseTestBackendDirect):
     pass
-
-
-class TestPyEthereum21BackendFuzz(BaseTestBackendFuzz):
-    pass
-
-
-
-#TestPyEthereum21EVMStateFuzzer = EVMStateFuzzer.TestCase
-#TestPyEthereum21EVMStateFuzzer.settings = settings(max_examples=20, stateful_step_count=50)

--- a/tests/core/test_mock_backend.py
+++ b/tests/core/test_mock_backend.py
@@ -2,10 +2,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-from hypothesis import (
-    settings,
-)
-
 from eth_tester import (
     EthereumTester,
     MockBackend,
@@ -13,8 +9,6 @@ from eth_tester import (
 
 from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
-    BaseTestBackendFuzz,
-    EVMStateFuzzer,
 )
 
 
@@ -27,12 +21,3 @@ def eth_tester():
 
 class TestMockBackendDirect(BaseTestBackendDirect):
     supports_evm_execution = False
-
-
-#class TestMockBackendFuzz(BaseTestBackendFuzz):
-#    pass
-
-
-
-#TestPyEthereum16EVMStateFuzzer = EVMStateFuzzer.TestCase
-#TestPyEthereum16EVMStateFuzzer.settings = settings(max_examples=20, stateful_step_count=50)


### PR DESCRIPTION
### What was wrong?

I am a little to in love with property based testing and originally wrote some fuzz testers for the backends.  They mostly aren't used and are not really useful.

### How was it fixed?

Removed them.

#### Cute Animal Picture

![bn-gy930_catfly_g_20150215224256](https://user-images.githubusercontent.com/824194/38275281-a50b1002-374e-11e8-80b3-3ed10c5ddfa4.jpg)
