### PR TITLE
update PyEthereum16Backend import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ use.
 
 ```python
 >>> from eth_tester import EthereumTester
->>> from eth_tester.backends.pyethereum import PyEthereum16Backend
+>>> from eth_tester import PyEthereum16Backend
 >>> t = EthereumTester(backend=PyEthereum16Backend())
 ```
 


### PR DESCRIPTION
### What was wrong?
PyEthereum16Backend import example is outdated.


### How was it fixed?
updated it.


