### PR TITLE
Insert gas value when creating tx for gas estimation

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -5,6 +5,7 @@ import time
 
 from cytoolz import (
     frequencies,
+    assoc,
 )
 
 import rlp
@@ -468,8 +469,8 @@ class PyEVMBackend(object):
         EVMInvalidInstruction: TransactionFailed,
         EVMRevert: TransactionFailed})
     def estimate_gas(self, transaction):
-        evm_transaction = self._get_normalized_and_unsigned_evm_transaction(dict(
-            transaction))
+        evm_transaction = self._get_normalized_and_unsigned_evm_transaction(assoc(
+            transaction, 'gas', 21000))
         spoofed_transaction = EVMSpoofTransaction(evm_transaction, from_=transaction['from'])
 
         return self.chain.estimate_gas(spoofed_transaction)

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -728,7 +728,7 @@ class BaseTestBackendDirect(object):
             'willThrow',
         )
         with pytest.raises(TransactionFailed):
-            eth_tester.estimate_gas(call_will_throw_transaction)
+            eth_tester.estimate_gas(dissoc(call_will_throw_transaction, 'gas'))
 
         call_set_value_transaction = _make_call_throws_transaction(
             eth_tester,
@@ -736,7 +736,7 @@ class BaseTestBackendDirect(object):
             'setValue',
             fn_args=(2,),
         )
-        gas_estimation = eth_tester.estimate_gas(call_set_value_transaction)
+        gas_estimation = eth_tester.estimate_gas(dissoc(call_set_value_transaction, 'gas'))
         assert gas_estimation
 
     #


### PR DESCRIPTION
Its a required field for transaction objects

### What was wrong?
Gas estimation fails if a gas parameter is not supplied.


### How was it fixed?
Insert a value for gas when creating the evm transaction.


#### Cute Animal Picture

![Cute animal picture](https://www.greyhoundgang.org/wp-content/uploads/2016/11/alienface.jpg)
