### PR TITLE
WIP: transaction status

### DIFF
--- a/eth_tester/backends/pyethereum/serializers.py
+++ b/eth_tester/backends/pyethereum/serializers.py
@@ -22,7 +22,8 @@ def serialize_transaction_receipt(block,
                                   transaction,
                                   transaction_receipt,
                                   transaction_index,
-                                  is_pending):
+                                  is_pending,
+                                  status=None):
     if hasattr(block, 'transaction_list'):
         origin_gas = block.transaction_list[0].startgas
     elif hasattr(block, 'transactions'):
@@ -39,7 +40,7 @@ def serialize_transaction_receipt(block,
     else:
         contract_addr = None
 
-    return {
+    serialized_transaction = {
         "transaction_hash": transaction.hash,
         "transaction_index": None if is_pending else transaction_index,
         "block_number": None if is_pending else block.number,
@@ -52,6 +53,11 @@ def serialize_transaction_receipt(block,
             for log_index, log in enumerate(transaction_receipt.logs)
         ],
     }
+
+    if status is not None:
+        serialized_transaction['status'] = status
+
+    return serialized_transaction
 
 
 def serialize_transaction_hash(block, transaction, transaction_index, is_pending):

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -315,6 +315,37 @@ class BaseTestBackendDirect(object):
 
         self._send_and_check_transaction(eth_tester, test_transaction, accounts[0])
 
+    @pytest.mark.parametrize(
+        'test_transaction',
+        (
+            SIMPLE_TRANSACTION,
+            TRANSACTION_WTH_NONCE,
+            CONTRACT_TRANSACTION_EMPTY_TO,
+            CONTRACT_TRANSACTION_MISSING_TO,
+        ),
+        ids=[
+            'Simple transaction',
+            'Transaction with nonce',
+            'Create Contract - empty to',
+            'Create Contract - missing to',
+        ],
+    )
+    def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
+        if eth_tester.backend.__class__.__name__ == 'PyEthereum16Backend':
+            return
+
+        backend = eth_tester.backend.__class__()
+        backend.set_fork_block(FORK_BYZANTIUM, 0)
+        byzantium_eth_tester = eth_tester.__class__(backend=backend)
+        accounts = byzantium_eth_tester.get_accounts()
+        assert accounts, "No accounts available for transaction sending"
+
+        transaction = assoc(test_transaction, 'from', accounts[0])
+        txn_hash = byzantium_eth_tester.send_transaction(transaction)
+        txn = byzantium_eth_tester.get_transaction_receipt(txn_hash)
+
+        assert txn['status']
+
     def test_block_number_auto_mine_transactions_enabled(self, eth_tester):
         eth_tester.mine_blocks()
         eth_tester.enable_auto_mine_transactions()

--- a/eth_tester/validation/byzantium.py
+++ b/eth_tester/validation/byzantium.py
@@ -1,0 +1,33 @@
+from cytoolz import (
+    partial,
+)
+
+from eth_tester.exceptions import (
+    ValidationError,
+)
+from eth_tester.validation.common import (
+    if_not_null, validate_dict
+)
+from eth_tester.validation.default import (
+    DefaultValidator,
+)
+from eth_tester.validation.outbound import (
+    RECEIPT_VALIDATORS,
+)
+
+
+def validate_status(value):
+    if value is not 0 or value is not 1:
+        raise ValidationError(
+            "Status must be 1 or 0"
+        )
+
+
+RECEIPT_VALIDATORS["status"] = if_not_null(validate_status)
+
+validate_outbound_receipt = partial(validate_dict, key_validators=RECEIPT_VALIDATORS)
+
+
+class ByzantiumValidator(DefaultValidator):
+
+    validate_outbound_receipt = staticmethod(validate_outbound_receipt)

--- a/tests/backends/test_pyethereum21.py
+++ b/tests/backends/test_pyethereum21.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import os
 import pytest
 
 from eth_tester import (
@@ -23,6 +24,8 @@ pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
 def eth_tester():
     if not is_pyethereum21_available():
         pytest.skip("PyEthereum >=2.0.0,<2.2.0 not available")
+    if os.environ.get('ETHEREUM_TESTER_VALIDATOR') is not None:
+        del os.environ['ETHEREUM_TESTER_VALIDATOR']
     backend = PyEthereum21Backend()
     return EthereumTester(backend=backend)
 


### PR DESCRIPTION
Add `status` attribute when calling `get_transaction_receipt` only when settted Byzantium fork