### PR TITLE
Add `status` field to Byzantium tx receipts

### DIFF
--- a/eth_tester/backends/mock/serializers.py
+++ b/eth_tester/backends/mock/serializers.py
@@ -51,4 +51,5 @@ def serialize_receipt(transaction, block, transaction_index, is_pending):
         partial(assoc, key='block_number', value=block_number),
         partial(assoc, key='block_hash', value=block_hash),
         partial(assoc, key='transaction_index', value=transaction_index),
+        partial(assoc, key='state_root', value=b'\x00'),
     )

--- a/eth_tester/backends/pyethereum/serializers.py
+++ b/eth_tester/backends/pyethereum/serializers.py
@@ -51,6 +51,7 @@ def serialize_transaction_receipt(block,
             serialize_log(block, transaction, transaction_index, log, log_index, is_pending)
             for log_index, log in enumerate(transaction_receipt.logs)
         ],
+        "state_root": transaction_receipt.state_root,
     }
 
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -391,6 +391,7 @@ class PyEVMBackend(object):
         )
         is_pending = block.number == self.chain.get_block().number
         block_receipts = block.get_receipts(self.chain.chaindb)
+
         return serialize_transaction_receipt(
             block,
             block_receipts,

--- a/eth_tester/backends/pyevm/serializers.py
+++ b/eth_tester/backends/pyevm/serializers.py
@@ -77,7 +77,13 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
     }
 
 
-def serialize_transaction_receipt(block, receipts, transaction, transaction_index, is_pending):
+def serialize_transaction_receipt(
+    block,
+    receipts,
+    transaction,
+    transaction_index,
+    is_pending
+):
     receipt = receipts[transaction_index]
 
     if transaction.to == b'':
@@ -105,6 +111,7 @@ def serialize_transaction_receipt(block, receipts, transaction, transaction_inde
             serialize_log(block, transaction, transaction_index, log, log_index, is_pending)
             for log_index, log in enumerate(receipt.logs)
         ],
+        'state_root': receipt.state_root,
     }
 
 

--- a/eth_tester/normalization/outbound.py
+++ b/eth_tester/normalization/outbound.py
@@ -138,6 +138,7 @@ RECEIPT_NORMALIZERS = {
         normalizer=to_checksum_address,
     ),
     "logs": partial(normalize_array, normalizer=normalize_log_entry),
+    "state_root": identity,
 }
 
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -1276,3 +1276,33 @@ class BaseTestBackendDirect(object):
         eth_tester.set_fork_block(fork_name, set_to_block)
         after_set_fork_block = eth_tester.get_fork_block(fork_name)
         assert after_set_fork_block == set_to_block
+
+    @pytest.mark.parametrize(
+        'test_transaction', (SIMPLE_TRANSACTION,), ids=['Simple transaction']
+    )
+    def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
+        backend = eth_tester.backend.__class__()
+        byzantium_eth_tester = eth_tester.__class__(backend=backend)
+        backend.set_fork_block(FORK_BYZANTIUM, 0)
+        accounts = byzantium_eth_tester.get_accounts()
+        assert accounts, "No accounts available for transaction sending"
+
+        transaction = assoc(test_transaction, 'from', accounts[0])
+        txn_hash = byzantium_eth_tester.send_transaction(transaction)
+        txn = byzantium_eth_tester.get_transaction_receipt(txn_hash)
+
+        assert 'status' in txn
+        assert txn['status'] == 1
+
+    @pytest.mark.parametrize(
+        'test_transaction', (SIMPLE_TRANSACTION,), ids=['Simple transaction']
+    )
+    def test_get_transaction_receipt_pre_byzantium(self, eth_tester, test_transaction):
+        accounts = eth_tester.get_accounts()
+        assert accounts, "No accounts available for transaction sending"
+
+        transaction = assoc(test_transaction, 'from', accounts[0])
+        txn_hash = eth_tester.send_transaction(transaction)
+        txn = eth_tester.get_transaction_receipt(txn_hash)
+
+        assert 'status' not in txn

--- a/eth_tester/validation/outbound.py
+++ b/eth_tester/validation/outbound.py
@@ -116,6 +116,7 @@ RECEIPT_VALIDATORS = {
     "gas_used": validate_positive_integer,
     "contract_address": if_not_null(validate_canonical_address),
     "logs": partial(validate_array, validator=validate_log_entry),
+    "state_root": validate_bytes,
 }
 
 

--- a/tests/backends/test_pyethereum16.py
+++ b/tests/backends/test_pyethereum16.py
@@ -32,3 +32,15 @@ class TestPyEthereum16BackendDirect(BaseTestBackendDirect):
     @pytest.mark.skip(reason="v1.6 not supported")
     def test_call_query_previous_state(self, eth_tester):
         pass
+
+    @pytest.mark.skip(reason="v1.6 not supported")
+    def test_get_transaction_receipt_byzantium(self, eth_tester):
+        pass
+
+    @pytest.mark.skip(reason="v1.6 not supported")
+    def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
+        pass
+
+    @pytest.mark.skip(reason="v1.6 not supported")
+    def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
+        pass

--- a/tests/core/test_mock_backend.py
+++ b/tests/core/test_mock_backend.py
@@ -21,3 +21,11 @@ def eth_tester():
 
 class TestMockBackendDirect(BaseTestBackendDirect):
     supports_evm_execution = False
+
+    @pytest.mark.skip(reason="receipt status not supported in MockBackend")
+    def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
+        pass
+
+    @pytest.mark.skip(reason="receipt status not supported in MockBackend")
+    def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
+        pass

--- a/tests/core/validation/test_outbound_validation.py
+++ b/tests/core/validation/test_outbound_validation.py
@@ -184,7 +184,9 @@ def _make_receipt(transaction_hash=ZERO_32BYTES,
                   cumulative_gas_used=0,
                   gas_used=21000,
                   contract_address=None,
-                  logs=None):
+                  logs=None,
+                  state_root=b'\x00'
+                 ):
     return {
         "transaction_hash": transaction_hash,
         "transaction_index": transaction_index,
@@ -194,6 +196,7 @@ def _make_receipt(transaction_hash=ZERO_32BYTES,
         "gas_used": gas_used,
         "contract_address": contract_address,
         "logs": logs or [],
+        "state_root": state_root
     }
 
 


### PR DESCRIPTION
### What was wrong?
Receipts in `eth-tester` don't include `status` field. In Raiden, it prevents us from using `eth-tester` backend for our tests/CI.


### How was it fixed?
Status field was added for transactions  that occur after `FORK_BYZANTIUM`. I've used some ideas discussed in #93 


#### Cute Animal Picture

![Cute animal picture](https://i.imgur.com/rCqu9Hq.jpg)