### PR TITLE
Force py36 pyethereum21 test to debian 8: Jessie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
   py36-pyethereum21:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-jessie
         environment:
           TOXENV: py36-pyethereum21
   py35-pyevm:


### PR DESCRIPTION

### What was wrong?

Fixes #103 

Otherwise, we get a libcrypto-1.0.0 missing error when trying to install
scrypt for pyethereum21.

### How was it fixed?

Tweak the CircleCI environment to make sure the right libraries are available

#### Cute Animal Picture

![Cute animal picture](http://pinktreefrog.typepad.com/.a/6a0115717bd356970b0120a7302a17970b-pi)
