### PR TITLE
Pyevm upgrade a26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
   py36-pyethereum16:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-jessie
         environment:
           TOXENV: py36-pyethereum16
   py35-pyethereum21:

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -142,6 +142,16 @@ def get_default_genesis_params():
 def setup_tester_chain():
     from evm.chains.tester import MainnetTesterChain
     from evm.db import get_db_backend
+    from evm.vm.forks.byzantium import ByzantiumVM
+
+    class ByzantiumNoProofVM(ByzantiumVM):
+        """Byzantium VM rules, without validating any miner proof of work"""
+
+        def validate_seal(self, header):
+            pass
+
+    class MainnetTesterNoProofChain(MainnetTesterChain):
+        vm_configuration = ((0, ByzantiumNoProofVM), )
 
     genesis_params = get_default_genesis_params()
     account_keys = get_default_account_keys()
@@ -149,7 +159,7 @@ def setup_tester_chain():
 
     base_db = get_db_backend()
 
-    chain = MainnetTesterChain.from_genesis(base_db, genesis_params, genesis_state)
+    chain = MainnetTesterNoProofChain.from_genesis(base_db, genesis_params, genesis_state)
     return account_keys, chain
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         'pytest>=3.2.1,<4.0.0',
         'pytest-xdist>=1.22.2,<2',
         'eth-abi>=1.0.0-beta.1,<2',
-        'eth-hash[pycryptodome]>=0.1.0a2,<1.0.0',
+        'eth-hash[pycryptodome]>=0.1.4,<1.0.0',
     ],
     'dev': [
         'bumpversion>=0.5.3,<1.0.0',
@@ -39,6 +39,7 @@ extras_require = {
 extras_require['dev'] = (
     extras_require['dev'] +
     extras_require['test'] +
+    extras_require['py-evm'] +
     extras_require['lint']
 )
 # convenience in case someone leaves out the `-`

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.2.0a18",
+        "py-evm==0.2.0a26",
     ],
 }
 


### PR DESCRIPTION
### What was wrong?

Fix #104 

### How was it fixed?

The tester chain was not ignoring proof of work by default in py-evm alpha 26. Created a subclass that correctly ignores PoW.

Plus bonus upgrade of eth-hash.

#### Cute Animal Picture

![Cute animal picture](https://data.whicdn.com/images/94113755/original.jpg)