### PR TITLE
use custom BackendDistributionNotFound class

### DIFF
--- a/eth_tester/backends/pyethereum/v16/main.py
+++ b/eth_tester/backends/pyethereum/v16/main.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import pkg_resources
-
 from semantic_version import (
     Spec,
 )
@@ -28,6 +26,7 @@ from eth_tester.exceptions import (
     TransactionNotFound,
     UnknownFork,
     TransactionFailed,
+    BackendDistributionNotFound,
 )
 from eth_tester.backends.base import BaseChainBackend
 from eth_tester.backends.pyethereum.utils import (
@@ -170,13 +169,13 @@ class PyEthereum16Backend(BaseChainBackend):
         if not is_pyethereum16_available():
             version = get_pyethereum_version()
             if version is None:
-                raise pkg_resources.DistributionNotFound(
+                raise BackendDistributionNotFound(
                     "The `ethereum` package is not available.  The "
                     "`PyEthereum16Backend` requires a 1.6.x version of the "
                     "ethereum package to be installed."
                 )
             elif version not in Spec('>=1.6.0,<1.7.0'):
-                raise pkg_resources.DistributionNotFound(
+                raise BackendDistributionNotFound(
                     "The `PyEthereum16Backend` requires a 1.6.x version of the "
                     "`ethereum` package.  Found {0}".format(version)
                 )

--- a/eth_tester/backends/pyethereum/v20/main.py
+++ b/eth_tester/backends/pyethereum/v20/main.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import pkg_resources
-
 from semantic_version import (
     Spec,
 )
@@ -27,6 +25,7 @@ from eth_tester.exceptions import (
     TransactionNotFound,
     UnknownFork,
     TransactionFailed,
+    BackendDistributionNotFound,
 )
 from eth_tester.backends.base import BaseChainBackend
 from eth_tester.backends.pyethereum.utils import (
@@ -206,13 +205,13 @@ class PyEthereum21Backend(BaseChainBackend):
         if not is_pyethereum21_available():
             version = get_pyethereum_version()
             if version is None:
-                raise pkg_resources.DistributionNotFound(
+                raise BackendDistributionNotFound(
                     "The `ethereum` package is not available.  The "
                     "`PyEthereum21Backend` requires a 2.0.0+ version of the "
                     "ethereum package to be installed."
                 )
             elif version not in Spec('>=2.0.0,<2.2.0'):
-                raise pkg_resources.DistributionNotFound(
+                raise BackendDistributionNotFound(
                     "The `PyEthereum21Backend` requires a 2.0.0+ version of the "
                     "`ethereum` package.  Found {0}".format(version)
                 )

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -33,6 +33,7 @@ from eth_tester.exceptions import (
     TransactionNotFound,
     UnknownFork,
     TransactionFailed,
+    BackendDistributionNotFound,
 )
 
 from eth_tester.utils.formatting import (
@@ -271,7 +272,7 @@ class PyEVMBackend(object):
         self.fork_config = {}
 
         if not is_pyevm_available():
-            raise pkg_resources.DistributionNotFound(
+            raise BackendDistributionNotFound(
                 "The `py-evm` package is not available.  The "
                 "`PyEVMBackend` requires py-evm to be installed and importable. "
                 "Please install the `py-evm` library."

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import pkg_resources
 import time
 
 from cytoolz import (

--- a/eth_tester/exceptions.py
+++ b/eth_tester/exceptions.py
@@ -28,3 +28,7 @@ class AccountLocked(Exception):
 
 class TransactionFailed(Exception):
     pass
+
+
+class BackendDistributionNotFound(Exception):
+    pass


### PR DESCRIPTION
### What was wrong?

The `pkg_resources.DistributionNotFound` class doesn't actually accept custom error messages.

```
>>> import pkg_resources
>>> raise pkg_resources.DistributionNotFound("abc")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
pkg_resources.DistributionNotFound: <exception str() failed>
```
as can be seen, `abc` is thrown away. 

https://github.com/pypa/setuptools/blob/cca86c7f1d4040834c3265ccecdd9e21b4036df5/pkg_resources/__init__.py#L293


### How was it fixed?

Create a new Exception type

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/130362/42543688-f02a49bc-847a-11e8-881c-35a584c75778.png)

