### PR TITLE
Compatibility with py-evm v0.2.0-alpha.28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,18 +58,6 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
-  py35-pyethereum16:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-pyethereum16
-  py36-pyethereum16:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6-jessie
-        environment:
-          TOXENV: py36-pyethereum16
   py35-pyethereum21:
     <<: *common
     docker:
@@ -102,8 +90,6 @@ workflows:
       - lint
       - py35-core
       - py36-core
-      - py35-pyethereum16
-      - py36-pyethereum16
       - py35-pyethereum21
       - py36-pyethereum21
       - py35-pyevm

--- a/README.md
+++ b/README.md
@@ -708,7 +708,6 @@ $ pip install eth-tester[<backend-name>]
 You should replace `<backend-name>` with the name of the desired testing
 backend.  Available backends are:
 
-* `pyethereum16`: [PyEthereum v1.6.x](https://pypi.python.org/pypi/ethereum/1.6.1)
 * `pyethereum21`: [PyEthereum v2.1.0+](https://pypi.python.org/pypi/ethereum)
 * `py-evm`: [PyEVM (alpha)](https://pypi.python.org/pypi/py-evm) **(experimental)**
 
@@ -721,8 +720,8 @@ use.
 
 ```python
 >>> from eth_tester import EthereumTester
->>> from eth_tester import PyEthereum16Backend
->>> t = EthereumTester(backend=PyEthereum16Backend())
+>>> from eth_tester import PyEthereum21Backend
+>>> t = EthereumTester(backend=PyEthereum21Backend())
 ```
 
 Ethereum tester also supports configuration using the environment variable
@@ -733,7 +732,6 @@ backend class you wish to use.
 
 Ethereum tester can be used with the following backends.
 
-* PyEthereum 1.6.x (default)
 * PyEthereum 2.0.0+ (experimental)
 * PyEVM (experimental)
 * MockBackend
@@ -746,15 +744,6 @@ It mocks out all of the objects and interactions.
 ```python
 >>> from eth_tester import MockBackend
 >>> t = EthereumTester(MockBackend())
-```
-
-#### PyEthereum 1.6.x
-
-Uses the PyEthereum library at version `v1.6.x`
-
-```python
->>> from eth_tester import PyEthereum16Backend
->>> t = EthereumTester(PyEthereum16Backend())
 ```
 
 #### PyEthereum 2.0.0+

--- a/README.md
+++ b/README.md
@@ -181,41 +181,7 @@ object accepts the following parameters.
 ### Fork Rules
 <a id="fork-rules"></a>
 
-Ethereum tester supports the following hard forks.
-
-- Homestead
-- DAO
-- Spurious Dragon
-- Tangerine Whistle
-- Byzantium
-
-By default, all forks will be active at the genesis block (block 0).
-
-Manual configuration and retrieval of fork rules can be done with the following
-API.
-
-#### `EthereumTester.get_supported_forks()`
-
-Returns a `set` of the supported fork names.
-
-#### `EthereumTester.set_fork_block(fork_name, fork_block)`
-
-Sets the fork rules for the fork denoted by `fork_name` to activate at `fork_block`.
-
-The `fork_name` parameter must be one of the following strings.
-
-- Homestead: `"FORK_HOMESTEAD"`
-- DAO: `"FORK_DAO"`
-- Spurious Dragon: `"FORK_SPURIOUS_DRAGON"`
-- Tangerine Whistle: `"FORK_TANGERINE_WHISTLE"`
-- Byzantium: `"FORK_BYZANTIUM"`
-
-#### `EthereumTester.get_fork_block(fork_name)`
-
-Returns the block number on which the named fork will activate.
-
-The `fork_name` parameter follows the same restrictions as `set_fork_block`
-
+Ethereum tester uses the Byzantium rules, starting at block 0.
 
 ### Time Travel
 <a id="time-travel"></a>

--- a/eth_tester/backends/base.py
+++ b/eth_tester/backends/base.py
@@ -21,21 +21,6 @@ class BaseChainBackend(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
-    # Fork block numbers
-    #
-    @abstractmethod
-    def get_supported_forks(self):
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    @abstractmethod
-    def set_fork_block(self, fork_name, fork_block):
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    @abstractmethod
-    def get_fork_block(self, fork_name):
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    #
     # Meta
     #
     @abstractmethod

--- a/eth_tester/backends/mock/main.py
+++ b/eth_tester/backends/mock/main.py
@@ -23,13 +23,9 @@ from eth_utils import (
 from eth_tester.backends.base import (
     BaseChainBackend,
 )
-from eth_tester.constants import (
-    KNOWN_FORKS,
-)
 from eth_tester.exceptions import (
     BlockNotFound,
     TransactionNotFound,
-    UnknownFork,
 )
 
 from eth_tester.utils.accounts import (
@@ -125,21 +121,6 @@ class MockBackend(BaseChainBackend):
     @property
     def account_state_lookup(self):
         return dict(self.alloc)
-
-    #
-    # Fork block numbers
-    #
-    def get_supported_forks(self):
-        return KNOWN_FORKS
-
-    def set_fork_block(self, fork_name, fork_block):
-        self.fork_blocks[fork_name] = fork_block
-
-    def get_fork_block(self, fork_name):
-        try:
-            return self.fork_blocks[fork_name]
-        except KeyError:
-            raise UnknownFork("Unknown fork: {0}".format(fork_name))
 
     #
     # Meta

--- a/eth_tester/backends/pyethereum/v16/main.py
+++ b/eth_tester/backends/pyethereum/v16/main.py
@@ -24,7 +24,6 @@ from eth_tester.constants import (
 from eth_tester.exceptions import (
     BlockNotFound,
     TransactionNotFound,
-    UnknownFork,
     TransactionFailed,
     BackendDistributionNotFound,
 )
@@ -181,32 +180,6 @@ class PyEthereum16Backend(BaseChainBackend):
                 )
         self.fork_blocks = {}
         self.reset_to_genesis()
-
-    #
-    # Fork Rules
-    #
-    def get_supported_forks(self):
-        return SUPPORTED_FORKS
-
-    def set_fork_block(self, fork_name, fork_block):
-        if fork_name == FORK_HOMESTEAD:
-            self.evm.env.config['HOMESTEAD_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_DAO:
-            self.evm.env.config['DAO_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_SPURIOUS_DRAGON:
-            self.evm.env.config['ANTI_DOS_FORK_BLKNUM'] = fork_block or 0
-            self.evm.env.config['SPURIOUS_DRAGON_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_TANGERINE_WHISTLE:
-            self.evm.env.config['CLEARING_FORK_BLKNUM'] = fork_block or 0
-        else:
-            raise UnknownFork("Unknown fork name: {0}".format(fork_name))
-        self.fork_blocks[fork_name] = fork_block
-
-    def get_fork_block(self, fork_name):
-        if fork_name in self.get_supported_forks():
-            return self.fork_blocks.get(fork_name)
-        else:
-            raise UnknownFork("Unknown fork name: {0}".format(fork_name))
 
     #
     # Snapshots

--- a/eth_tester/backends/pyethereum/v20/main.py
+++ b/eth_tester/backends/pyethereum/v20/main.py
@@ -23,7 +23,6 @@ from eth_tester.constants import (
 from eth_tester.exceptions import (
     BlockNotFound,
     TransactionNotFound,
-    UnknownFork,
     TransactionFailed,
     BackendDistributionNotFound,
 )
@@ -217,40 +216,6 @@ class PyEthereum21Backend(BaseChainBackend):
                 )
         self.fork_blocks = {}
         self.reset_to_genesis()
-
-    #
-    # Fork block numbers
-    #
-    def get_supported_forks(self):
-        return SUPPORTED_FORKS
-
-    def set_fork_block(self, fork_name, fork_block):
-        if fork_name == FORK_HOMESTEAD:
-            self.evm.chain.env.config['HOMESTEAD_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_DAO:
-            # NOTE: REALLY WEIRD HACK to get the dao_fork_blk to accept block 0
-            if not fork_block:
-                self.evm.chain.env.config['DAO_FORK_BLKNUM'] = 999999999999999
-            else:
-                self.evm.chain.env.config['DAO_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_SPURIOUS_DRAGON:
-            # pyethereum seems to use both of these.
-            self.evm.chain.env.config['ANTI_DOS_FORK_BLKNUM'] = fork_block or 0
-            self.evm.chain.env.config['SPURIOUS_DRAGON_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_TANGERINE_WHISTLE:
-            self.evm.chain.env.config['CLEARING_FORK_BLKNUM'] = fork_block or 0
-        elif fork_name == FORK_BYZANTIUM:
-            self.evm.chain.env.config['METROPOLIS_FORK_BLKNUM'] = fork_block or 0
-        else:
-            raise UnknownFork("Unknown fork name: {0}".format(fork_name))
-
-        self.fork_blocks[fork_name] = fork_block
-
-    def get_fork_block(self, fork_name):
-        if fork_name in self.get_supported_forks():
-            return self.fork_blocks.get(fork_name)
-        else:
-            raise UnknownFork("Unknown fork name: {0}".format(fork_name))
 
     #
     # Snapshot API

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -37,7 +37,6 @@ from eth_tester.constants import (
 from eth_tester.exceptions import (
     BlockNotFound,
     TransactionNotFound,
-    UnknownFork,
     TransactionFailed,
     BackendDistributionNotFound,
 )
@@ -319,31 +318,6 @@ class PyEVMBackend(object):
 
     def reset_to_genesis(self):
         self.account_keys, self.chain = setup_tester_chain()
-
-    #
-    # Fork block numbers
-    #
-    def get_supported_forks(self):
-        return SUPPORTED_FORKS
-
-    def set_fork_block(self, fork_name, fork_block):
-        if fork_name in self.get_supported_forks():
-            if fork_block is not None:
-                self.fork_config[fork_name] = fork_block
-            elif fork_block is None:
-                self.fork_config.pop(fork_name, None)
-        else:
-            raise UnknownFork("Unknown fork name: {0}".format(fork_name))
-        self.configure_forks()
-
-    def get_fork_block(self, fork_name):
-        if fork_name in self.get_supported_forks():
-            return self.fork_config.get(fork_name, None)
-        else:
-            raise UnknownFork("Unknown fork name: {0}".format(fork_name))
-
-    def configure_forks(self):
-        pass
 
     #
     # Meta

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.2.0a26",
+        "py-evm==0.2.0a28",
     ],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{35,36,py3}-{core}
-    py{35,36}-{pyethereum16,pyethereum21,pyevm}
+    py{35,36}-{pyethereum21,pyevm}
     lint
 
 [flake8]
@@ -12,12 +12,10 @@ exclude= tests/*
 usedevelop=True
 commands=
     core: py.test {posargs:tests/core}
-    pyethereum16: py.test {posargs:tests/backends/test_pyethereum16.py}
     pyethereum21: py.test {posargs:tests/backends/test_pyethereum21.py}
     pyevm: py.test {posargs:tests/backends/test_pyevm.py}
 deps =
     coincurve>=6.0.0
-    pyethereum16: rlp<1
     pyethereum21: rlp<1
 basepython =
     py35: python3.5
@@ -26,7 +24,6 @@ basepython =
 extras =
     test
     pyevm: py-evm
-    pyethereum16: pyethereum16
     pyethereum21: pyethereum21
 
 [testenv:lint]


### PR DESCRIPTION
- switch from `Chain` to `MiningChain` which means we have to stop using the prebuilt tester chain (although py-evm should probably switch to using a `MiningChain`)
- change module name from `evm` to `eth`
- change a keyword argument from header to `at_header`
- drop an unused `configure_forks` feature that was broken anyway, last I checked.

#### Cute Animal Picture

![Cute animal picture](http://cdn.earthporm.com/wp-content/uploads/2015/06/moose.jpg)
