### PR TITLE
Fix topic_list parameter implementation (matching and validation) to align with JSON-RPC spec

### DIFF
--- a/eth_tester/normalization/inbound.py
+++ b/eth_tester/normalization/inbound.py
@@ -27,13 +27,17 @@ from eth_tester.validation.inbound import (
 )
 
 
+def normalize_topic(topic):
+    if topic is None:
+        return None
+    else:
+        return decode_hex(topic)
+
+
 @to_tuple
 def normalize_topic_list(topics):
     for topic in topics:
-        if topic is None:
-            yield None
-        else:
-            yield decode_hex(topic)
+        yield normalize_topic(topic)
 
 
 @to_tuple
@@ -56,11 +60,11 @@ def normalize_filter_params(from_block, to_block, address, topics):
 
     if topics is None:
         yield topics
-    elif is_flat_topic_array(topics):
-        yield normalize_topic_list(topics)
-    elif all(is_flat_topic_array(item) for item in topics):
+    elif is_valid_topic_array(topics):
         yield tuple(
             normalize_topic_list(item)
+            if is_list_like(item) else
+            normalize_topic(item)
             for item
             in topics
         )

--- a/eth_tester/normalization/inbound.py
+++ b/eth_tester/normalization/inbound.py
@@ -23,7 +23,7 @@ from .common import (
 )
 
 from eth_tester.validation.inbound import (
-    is_flat_topic_array,
+    is_valid_topic_array,
 )
 
 

--- a/eth_tester/utils/filters.py
+++ b/eth_tester/utils/filters.py
@@ -1,3 +1,4 @@
+import itertools
 from eth_utils import (
     to_tuple,
     is_bytes,
@@ -83,19 +84,9 @@ def is_flat_topic_array(value):
     return is_tuple(value) and all(is_topic(item) for item in value)
 
 
-@to_tuple
-def validate_topic_array_items(value):
-    for item in value:
-        if is_tuple(item):
-            yield is_flat_topic_array(item)
-        else:
-            yield is_topic(item)
-
-
 def is_valid_with_nested_topic_array(value):
-    return bool(value) and is_tuple(value) and all(validate_topic_array_items(value))
-    #  return bool(value) and is_tuple(value) and all(
-    #      (is_flat_topic_array(item) if is_tuple(item) else is_topic(item) for item in value))
+    return bool(value) and is_tuple(value) and all(
+         (is_flat_topic_array(item) if is_tuple(item) else is_topic(item) for item in value))
 
 
 def is_topic_array(value):
@@ -144,17 +135,20 @@ def check_if_log_matches_flat_topics(log_topics, filter_topics):
         )
 
 
+def extrapolate_flat_topic_from_topic_list(value):
+    _value = tuple(item if is_tuple(item) else (item,) for item in value)
+    return itertools.product(*_value)
+
+
 def check_if_topics_match(log_topics, filter_topics):
     if filter_topics is None:
         return True
     elif is_flat_topic_array(filter_topics):
         return check_if_log_matches_flat_topics(log_topics, filter_topics)
-    # TODO: This isnt going to work
     elif is_valid_with_nested_topic_array(filter_topics):
         return any(
-            check_if_log_matches_flat_topics(log_topics, sub_filter_topics)
-            for sub_filter_topics
-            in filter_topics
+            check_if_log_matches_flat_topics(log_topics, topic_combination)
+            for topic_combination in extrapolate_flat_topic_from_topic_list(filter_topics)
         )
     else:
         raise ValueError("Unrecognized topics format: {0}".format(filter_topics))

--- a/eth_tester/validation/inbound.py
+++ b/eth_tester/validation/inbound.py
@@ -97,10 +97,12 @@ def validate_account(value):
         raise ValidationError("Address does not validate EIP55 checksum")
 
 
-def is_flat_topic_array(value):
+def is_valid_topic_array(value):
     if not is_list_like(value):
         return False
-    return all(is_topic(item) for item in value)
+    return all(
+        is_valid_topic_array(item) if is_list_like(item) else is_topic(item)
+        for item in value)
 
 
 def validate_filter_params(from_block, to_block, address, topics):
@@ -133,9 +135,7 @@ def validate_filter_params(from_block, to_block, address, topics):
         pass
     elif not is_list_like(topics):
         raise ValidationError(invalid_topics_message)
-    elif is_flat_topic_array(topics):
-        return True
-    elif all(is_flat_topic_array(item) for item in topics):
+    elif is_valid_topic_array(topics):
         return True
     else:
         raise ValidationError(invalid_topics_message)

--- a/tests/core/filter-utils/test_filter_helpers.py
+++ b/tests/core/filter-utils/test_filter_helpers.py
@@ -15,7 +15,7 @@ from eth_tester.utils.filters import (
     check_if_log_matches,
     is_topic,
     is_flat_topic_array,
-    is_nested_topic_array,
+    is_valid_with_nested_topic_array,
     is_topic_array,
 )
 
@@ -131,17 +131,17 @@ NESTED_TOPICS_E = (TOPIC_A, TOPICS_MANY, TOPICS_EMPTY)
         ([b'a', None, b'b'], False),
         (list(), False),
         ([None], False),
-        (TOPIC_A, False),
-        (TOPICS_EMPTY, False),
-        (TOPICS_SINGLE_NULL, False),
-        (TOPICS_MANY, False),
-        (TOPICS_MANY_WITH_NULL, False),
         (([],), False),
         (([tuple()],), False),
         ([tuple()], False),
         ((tuple(), []), False),
         ((TOPICS_EMPTY, (b'arst',)), False),
+        (TOPIC_A, False),
+        (TOPICS_EMPTY, False),
         # good values
+        (TOPICS_SINGLE_NULL, True),
+        (TOPICS_MANY, True),
+        (TOPICS_MANY_WITH_NULL, True),
         (NESTED_TOPICS_A, True),
         (NESTED_TOPICS_B, True),
         (NESTED_TOPICS_C, True),
@@ -149,8 +149,8 @@ NESTED_TOPICS_E = (TOPIC_A, TOPICS_MANY, TOPICS_EMPTY)
         (NESTED_TOPICS_E, True),
     )
 )
-def test_is_nested_topic_array(value, expected):
-    actual = is_nested_topic_array(value)
+def test_is_valid_with_nested_topic_array(value, expected):
+    actual = is_valid_with_nested_topic_array(value)
     assert actual is expected
 
 

--- a/tests/core/filter-utils/test_filter_helpers.py
+++ b/tests/core/filter-utils/test_filter_helpers.py
@@ -17,6 +17,7 @@ from eth_tester.utils.filters import (
     is_flat_topic_array,
     is_valid_with_nested_topic_array,
     is_topic_array,
+    extrapolate_flat_topic_from_topic_list,
 )
 
 
@@ -274,12 +275,12 @@ TOPICS_B_C_A = (TOPIC_B, TOPIC_C, TOPIC_A)
 
 
 FILTER_MATCH_ALL = tuple()
-FILTER_MATCH_ANY_ONE = (None,)
-FILTER_MATCH_ANY_TWO = (None, None)
-FILTER_MATCH_ANY_THREE = (None, None, None)
-FILTER_MATCH_ONLY_A = (TOPIC_A,)
-FILTER_MATCH_ONLY_B = (TOPIC_B,)
-FILTER_MATCH_ONLY_C = (TOPIC_C,)
+FILTER_MATCH_ONE_OR_MORE = (None,)
+FILTER_MATCH_TWO_OR_MORE = (None, None)
+FILTER_MATCH_THREE_OR_MORE = (None, None, None)
+FILTER_MATCH_A = (TOPIC_A,)
+FILTER_MATCH_B = (TOPIC_B,)
+FILTER_MATCH_C = (TOPIC_C,)
 FILTER_MATCH_A_ANY = (TOPIC_A, None)
 FILTER_MATCH_B_ANY = (TOPIC_B, None)
 FILTER_MATCH_C_ANY = (TOPIC_C, None)
@@ -310,38 +311,38 @@ FILTER_MATCH_A_C_B = (TOPIC_A, TOPIC_C, TOPIC_B)
         (TOPICS_B_A_C, FILTER_MATCH_ALL, True),
         (TOPICS_B_C_A, FILTER_MATCH_ALL, True),
         # length 1 matches
-        (TOPICS_EMPTY, FILTER_MATCH_ANY_ONE, False),
-        (TOPICS_ONLY_A, FILTER_MATCH_ANY_ONE, True),
-        (TOPICS_ONLY_B, FILTER_MATCH_ANY_ONE, True),
-        (TOPICS_ONLY_C, FILTER_MATCH_ANY_ONE, True),
-        (TOPICS_EMPTY, FILTER_MATCH_ONLY_A, False),
-        (TOPICS_EMPTY, FILTER_MATCH_ONLY_B, False),
-        (TOPICS_EMPTY, FILTER_MATCH_ONLY_C, False),
-        (TOPICS_ONLY_A, FILTER_MATCH_ONLY_A, True),
-        (TOPICS_ONLY_B, FILTER_MATCH_ONLY_B, True),
-        (TOPICS_ONLY_C, FILTER_MATCH_ONLY_C, True),
-        (TOPICS_ONLY_B, FILTER_MATCH_ONLY_A, False),
-        (TOPICS_ONLY_C, FILTER_MATCH_ONLY_A, False),
-        (TOPICS_ONLY_A, FILTER_MATCH_ONLY_B, False),
-        (TOPICS_ONLY_C, FILTER_MATCH_ONLY_B, False),
-        (TOPICS_ONLY_A, FILTER_MATCH_ONLY_C, False),
-        (TOPICS_ONLY_B, FILTER_MATCH_ONLY_C, False),
-        (TOPICS_A_A, FILTER_MATCH_ONLY_A, True),
-        (TOPICS_A_B, FILTER_MATCH_ONLY_A, True),
-        (TOPICS_A_C, FILTER_MATCH_ONLY_A, True),
-        (TOPICS_A_B_C, FILTER_MATCH_ONLY_A, True),
-        (TOPICS_A_C_B, FILTER_MATCH_ONLY_A, True),
-        (TOPICS_B_A, FILTER_MATCH_ONLY_A, False),
-        (TOPICS_B_C, FILTER_MATCH_ONLY_A, False),
-        (TOPICS_B_A_C, FILTER_MATCH_ONLY_A, False),
-        (TOPICS_B_C_A, FILTER_MATCH_ONLY_A, False),
+        (TOPICS_EMPTY, FILTER_MATCH_ONE_OR_MORE, False),
+        (TOPICS_ONLY_A, FILTER_MATCH_ONE_OR_MORE, True),
+        (TOPICS_ONLY_B, FILTER_MATCH_ONE_OR_MORE, True),
+        (TOPICS_ONLY_C, FILTER_MATCH_ONE_OR_MORE, True),
+        (TOPICS_EMPTY, FILTER_MATCH_A, False),
+        (TOPICS_EMPTY, FILTER_MATCH_B, False),
+        (TOPICS_EMPTY, FILTER_MATCH_C, False),
+        (TOPICS_ONLY_A, FILTER_MATCH_A, True),
+        (TOPICS_ONLY_B, FILTER_MATCH_B, True),
+        (TOPICS_ONLY_C, FILTER_MATCH_C, True),
+        (TOPICS_ONLY_B, FILTER_MATCH_A, False),
+        (TOPICS_ONLY_C, FILTER_MATCH_A, False),
+        (TOPICS_ONLY_A, FILTER_MATCH_B, False),
+        (TOPICS_ONLY_C, FILTER_MATCH_B, False),
+        (TOPICS_ONLY_A, FILTER_MATCH_C, False),
+        (TOPICS_ONLY_B, FILTER_MATCH_C, False),
+        (TOPICS_A_A, FILTER_MATCH_A, True),
+        (TOPICS_A_B, FILTER_MATCH_A, True),
+        (TOPICS_A_C, FILTER_MATCH_A, True),
+        (TOPICS_A_B_C, FILTER_MATCH_A, True),
+        (TOPICS_A_C_B, FILTER_MATCH_A, True),
+        (TOPICS_B_A, FILTER_MATCH_A, False),
+        (TOPICS_B_C, FILTER_MATCH_A, False),
+        (TOPICS_B_A_C, FILTER_MATCH_A, False),
+        (TOPICS_B_C_A, FILTER_MATCH_A, False),
         # length 2 matches
-        (TOPICS_EMPTY, FILTER_MATCH_ANY_TWO, False),
-        (TOPICS_A_A, FILTER_MATCH_ANY_TWO, True),
-        (TOPICS_A_B, FILTER_MATCH_ANY_TWO, True),
-        (TOPICS_ONLY_A, FILTER_MATCH_ANY_TWO, False),
-        (TOPICS_ONLY_B, FILTER_MATCH_ANY_TWO, False),
-        (TOPICS_ONLY_C, FILTER_MATCH_ANY_TWO, False),
+        (TOPICS_EMPTY, FILTER_MATCH_TWO_OR_MORE, False),
+        (TOPICS_A_A, FILTER_MATCH_TWO_OR_MORE, True),
+        (TOPICS_A_B, FILTER_MATCH_TWO_OR_MORE, True),
+        (TOPICS_ONLY_A, FILTER_MATCH_TWO_OR_MORE, False),
+        (TOPICS_ONLY_B, FILTER_MATCH_TWO_OR_MORE, False),
+        (TOPICS_ONLY_C, FILTER_MATCH_TWO_OR_MORE, False),
         (TOPICS_A_A, FILTER_MATCH_A_B, False),
         (TOPICS_A_B, FILTER_MATCH_A_B, True),
         (TOPICS_A_B_C, FILTER_MATCH_A_B, True),
@@ -370,26 +371,29 @@ FILTER_MATCH_A_C_B = (TOPIC_A, TOPIC_C, TOPIC_B)
         (TOPICS_A_B, FILTER_MATCH_ANY_C, False),
         (TOPICS_A_B_C, FILTER_MATCH_ANY_C, False),
         # length 3 matches
-        (TOPICS_EMPTY, FILTER_MATCH_ANY_THREE, False),
-        (TOPICS_A_B_C, FILTER_MATCH_ANY_THREE, True),
-        (TOPICS_A_C_B, FILTER_MATCH_ANY_THREE, True),
-        (TOPICS_B_A_C, FILTER_MATCH_ANY_THREE, True),
-        (TOPICS_B_C_A, FILTER_MATCH_ANY_THREE, True),
-        (TOPICS_A_A, FILTER_MATCH_ANY_THREE, False),
+        (TOPICS_EMPTY, FILTER_MATCH_THREE_OR_MORE, False),
+        (TOPICS_A_B_C, FILTER_MATCH_THREE_OR_MORE, True),
+        (TOPICS_A_C_B, FILTER_MATCH_THREE_OR_MORE, True),
+        (TOPICS_B_A_C, FILTER_MATCH_THREE_OR_MORE, True),
+        (TOPICS_B_C_A, FILTER_MATCH_THREE_OR_MORE, True),
+        (TOPICS_A_A, FILTER_MATCH_THREE_OR_MORE, False),
         (TOPICS_A_B_C, FILTER_MATCH_A_B_C, True),
         (TOPICS_A_C_B, FILTER_MATCH_A_B_C, False),
         (TOPICS_A_C_B, FILTER_MATCH_A_C_B, True),
         (TOPICS_A_B_C, FILTER_MATCH_A_C_B, False),
-        # nested matches
-        (TOPICS_EMPTY, (FILTER_MATCH_ONLY_A, FILTER_MATCH_ONLY_B, FILTER_MATCH_ONLY_C), False),
-        (TOPICS_ONLY_A, (FILTER_MATCH_ONLY_A, FILTER_MATCH_ONLY_B, FILTER_MATCH_ONLY_C), True),
-        (TOPICS_ONLY_B, (FILTER_MATCH_ONLY_A, FILTER_MATCH_ONLY_B, FILTER_MATCH_ONLY_C), True),
-        (TOPICS_ONLY_C, (FILTER_MATCH_ONLY_A, FILTER_MATCH_ONLY_B, FILTER_MATCH_ONLY_C), True),
-        (TOPICS_A_B, (FILTER_MATCH_ONLY_B, FILTER_MATCH_ONLY_C), False),
-        (TOPICS_A_B, (FILTER_MATCH_ONLY_B, FILTER_MATCH_ONLY_C, FILTER_MATCH_ONLY_A), True),
+        # positional topic options matches
+        (TOPICS_EMPTY, (FILTER_MATCH_A, FILTER_MATCH_B, FILTER_MATCH_C), False),
+        (TOPICS_ONLY_A, (FILTER_MATCH_A, FILTER_MATCH_B, FILTER_MATCH_C), False),
+        (TOPICS_ONLY_B, (FILTER_MATCH_A, FILTER_MATCH_B, FILTER_MATCH_C), False),
+        (TOPICS_ONLY_C, (FILTER_MATCH_A, FILTER_MATCH_B, FILTER_MATCH_C), False),
+        (TOPICS_A_B, (FILTER_MATCH_B, FILTER_MATCH_C), False),
+        (TOPICS_A_B, (FILTER_MATCH_B, FILTER_MATCH_C, FILTER_MATCH_A), False),
         (TOPICS_A_C, (FILTER_MATCH_A_ANY, FILTER_MATCH_ANY_A), True),
         (TOPICS_B_A, (FILTER_MATCH_A_ANY, FILTER_MATCH_ANY_A), True),
-        (TOPICS_B_C, (FILTER_MATCH_A_ANY, FILTER_MATCH_ANY_A), False),
+        (TOPICS_B_C, (FILTER_MATCH_A_ANY, FILTER_MATCH_ANY_A), True),
+        (TOPICS_A_B_C, (FILTER_MATCH_A, FILTER_MATCH_A_B_C, FILTER_MATCH_C), True),
+        (TOPICS_A_B_C, (FILTER_MATCH_A, FILTER_MATCH_A_C_B, FILTER_MATCH_C), True),
+        (TOPICS_A_B_C, (FILTER_MATCH_A, FILTER_MATCH_A_C_B, TOPIC_C), True),
     ),
     ids=topic_id,
 )
@@ -466,8 +470,8 @@ def _make_filter(from_block=None, to_block=None, topics=None, addresses=None):
         # topics
         (_make_log(topics=(TOPIC_A,)), _make_filter(topics=FILTER_MATCH_ALL), True),
         (_make_log(topics=(TOPIC_A, TOPIC_B)), _make_filter(topics=FILTER_MATCH_ALL), True),
-        (_make_log(topics=(TOPIC_A,)), _make_filter(topics=FILTER_MATCH_ONLY_A), True),
-        (_make_log(topics=(TOPIC_B,)), _make_filter(topics=FILTER_MATCH_ONLY_A), False),
+        (_make_log(topics=(TOPIC_A,)), _make_filter(topics=FILTER_MATCH_A), True),
+        (_make_log(topics=(TOPIC_B,)), _make_filter(topics=FILTER_MATCH_A), False),
         (_make_log(topics=(TOPIC_A, TOPIC_A)), _make_filter(topics=FILTER_MATCH_A_ANY), True),
         (_make_log(topics=(TOPIC_A, TOPIC_B)), _make_filter(topics=FILTER_MATCH_A_ANY), True),
         (_make_log(topics=(TOPIC_B, TOPIC_A)), _make_filter(topics=FILTER_MATCH_A_ANY), False),
@@ -493,3 +497,31 @@ def _make_filter(from_block=None, to_block=None, topics=None, addresses=None):
 def test_check_if_log_matches(log_entry, filter_params, expected):
     actual = check_if_log_matches(log_entry, **filter_params)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'topic_list_input,expected_flat_topics',
+    (
+        (
+            ('A', ('A','B'), 'A'),
+            (
+                ('A', 'A', 'A'),
+                ('A', 'B', 'A')
+            ),
+        ),
+        (
+            ('A', ('A','B', 'C'), ('A', 'B')),
+            (
+                ('A', 'A', 'A'),
+                ('A', 'A', 'B'),
+                ('A', 'B', 'A'),
+                ('A', 'B', 'B'),
+                ('A', 'C', 'A'),
+                ('A', 'C', 'B')
+            ),
+        )
+    )
+)
+def test_extrapolate_flat_topic_from_topic_list(topic_list_input, expected_flat_topics):
+    assert tuple(extrapolate_flat_topic_from_topic_list(topic_list_input)) == expected_flat_topics
+

--- a/tests/core/filter-utils/test_filter_helpers.py
+++ b/tests/core/filter-utils/test_filter_helpers.py
@@ -101,7 +101,7 @@ TOPICS_MANY_WITH_NULL = (TOPIC_A, None, TOPIC_B)
         (TOPICS_MANY_WITH_NULL, True),
     )
 )
-def test_is_flat_topic_array(value, expected):
+def test_is_valid_topic_array_with_flat_topic_arrays(value, expected):
     actual = is_flat_topic_array(value)
     assert actual is expected
 
@@ -110,6 +110,7 @@ NESTED_TOPICS_A = (TOPICS_EMPTY,)
 NESTED_TOPICS_B = (TOPICS_EMPTY, TOPICS_SINGLE_NULL)
 NESTED_TOPICS_C = (TOPICS_SINGLE_NULL, TOPICS_MANY)
 NESTED_TOPICS_D = (TOPICS_MANY_WITH_NULL, TOPICS_MANY, TOPICS_EMPTY)
+NESTED_TOPICS_E = (TOPIC_A, TOPICS_MANY, TOPICS_EMPTY)
 
 
 @pytest.mark.parametrize(
@@ -145,6 +146,7 @@ NESTED_TOPICS_D = (TOPICS_MANY_WITH_NULL, TOPICS_MANY, TOPICS_EMPTY)
         (NESTED_TOPICS_B, True),
         (NESTED_TOPICS_C, True),
         (NESTED_TOPICS_D, True),
+        (NESTED_TOPICS_E, True),
     )
 )
 def test_is_nested_topic_array(value, expected):

--- a/tests/core/validation/test_inbound_validation.py
+++ b/tests/core/validation/test_inbound_validation.py
@@ -161,6 +161,7 @@ TOPIC_B = encode_hex(b'\x00' * 31 + b'\x02')
         (_make_filter_params(topics=[TOPIC_A, TOPIC_B]), True),
         (_make_filter_params(topics=[TOPIC_A, None]), True),
         (_make_filter_params(topics=[[TOPIC_A], [TOPIC_B]]), True),
+        (_make_filter_params(topics=[TOPIC_A, [TOPIC_B, TOPIC_A]]), True),
         (_make_filter_params(topics=[[TOPIC_A], [TOPIC_B, None]]), True),
         (_make_filter_params(topics=[ADDRESS_A]), False),
         (_make_filter_params(topics=[ADDRESS_A, TOPIC_B]), False),


### PR DESCRIPTION
### What was wrong?

Validators disallow topics lists such as:
[TOPICA, [TOPICB, TOPICC], TOPICD]

EDIT: fixes #119

### How was it fixed?
The topic validators were extended to check the validity of single items along with flat topic arrays.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/43481235-3f70fe04-94ba-11e8-8d80-18dc4fb4a7ae.png)