### PR TITLE
fixed filters to work correctly when to_block points to latest block

### DIFF
--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -605,7 +605,7 @@ class EthereumTester(object):
 
         if is_integer(raw_from_block):
             if is_integer(raw_to_block):
-                upper_bound = raw_to_block
+                upper_bound = raw_to_block + 1
             else:
                 upper_bound = self.get_block_by_number('pending')['number']
             for block_number in range(raw_from_block, upper_bound):

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -1216,6 +1216,28 @@ class BaseTestBackendDirect(object):
         direct_logs_all = eth_tester.get_logs(from_block=0)
         assert len(logs_changes) == len(logs_all) == len(direct_logs_all) == 2
 
+    def test_log_filter_includes_latest_block_with_to_block(self, eth_tester):
+        self.skip_if_no_evm_execution()
+
+        emitter_address = _deploy_emitter(eth_tester)
+        no_of_events = 2
+        for i in range(1, no_of_events + 1):
+            _call_emitter(
+                eth_tester,
+                emitter_address,
+                'logSingle',
+                [EMITTER_ENUM['LogSingleWithIndex'], i],
+            )
+
+        filter_any_id = eth_tester.create_log_filter(
+            from_block=0,
+            to_block=eth_tester.get_block_by_number('latest')['number']
+        )
+
+        logs_changes = eth_tester.get_only_filter_changes(filter_any_id)
+        logs_all = eth_tester.get_all_filter_logs(filter_any_id)
+        assert len(logs_changes) == len(logs_all) == no_of_events
+
     def test_delete_filter(self, eth_tester):
         self.skip_if_no_evm_execution()
 


### PR DESCRIPTION
### What was wrong?

filter didn't include logs  from block with `blockNumber=to_block`, when `to_block` was passed as a parameter to `create_log_filter`.

### How was it fixed?
Increased `upper_bound` by 1 when `to_block` is passed. 

https://github.com/ethereum/eth-tester/blob/a0ac1bc9dd5c467e41e6d841a374b28b72fa8701/eth_tester/main.py#L611
#### Cute Animal Picture

![Cute animal picture](https://www.50-best.com/images/cute_animal_pictures/pdog_with_glasses.jpg)
