### PR TITLE
Update eth-abi dependency to v2

### DIFF
--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -757,11 +757,11 @@ class BaseTestBackendDirect(object):
 
         raw_result = eth_tester.call(call_without_revert)
         result = _decode_throws_result('revert_contract', 'do_revert', raw_result)
-        assert result[0] == b'No ribbert'
+        assert result[0] == 'No ribbert'
 
         with pytest.raises(TransactionFailed) as excinfo:
             eth_tester.call(call_with_revert)
-        assert len(excinfo.value.args) > 0 and excinfo.value.args[0] == b'ribbert, ribbert'
+        assert len(excinfo.value.args) > 0 and excinfo.value.args[0] == 'ribbert, ribbert'
 
     #
     # Snapshot and Revert

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     url='https://github.com/ethereum/eth-tester',
     include_package_data=True,
     install_requires=[
-        "eth-abi>=1.2.1,<2",
+        "eth-abi>=2.0.0a1,<3.0.0",
         "eth-keys>=0.2.0-beta.3,<0.3.0",
         "eth-utils>=1.1.1,<2.0.0",
         "rlp>=0.6.0,<2.0.0",


### PR DESCRIPTION
### What was wrong?

This change is needed for `py-ethpm` and `pytest-ethereum` to update to `web3` v5.

#### Cute Animal Picture
🐇