### PR TITLE
Pin py-evm==0.2.0a38 and reflect SpoofTransaction import path change

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -60,7 +60,7 @@ if is_pyevm_available():
         InvalidInstruction as EVMInvalidInstruction,
         Revert as EVMRevert,
     )
-    from eth.utils.spoof import (
+    from eth.vm.spoof import (
         SpoofTransaction as EVMSpoofTransaction
     )
 else:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.2.0a33",
+        "py-evm==0.2.0a38",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

As of recent PR <https://github.com/ethereum/py-evm/pull/1662> - Installing `py-evm` version `0.2.0-alpha.38` results in a failing test suite that produces the following Exception:

`E   ModuleNotFoundError: No module named 'eth.utils'`

### How was it fixed?

- Pinned `py-evm` version to `0.2.0a38` in `setup.py`
- Updated one import `eth.utils.SpoofTransaction` -> `eth.vm.SpoofTransaction`

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/fd/86/d9/fd86d98e0dd6b166df11e348678a1a66.jpg)
