### PR TITLE
Update default vm rules

### DIFF
--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -9,7 +9,6 @@ import functools
 from eth_utils import (
     is_integer,
     is_same_address,
-    to_dict,
     to_list,
     to_tuple,
     to_int
@@ -59,12 +58,6 @@ def backend_proxy_method(backend_method_name):
         backend_method = getattr(self.backend, backend_method_name)
         return backend_method(*args, **kwargs)
     return proxy_method
-
-
-@to_dict
-def get_default_fork_blocks(supported_forks):
-    for fork_name in supported_forks:
-        yield (fork_name, None)
 
 
 def handle_auto_mining(func):


### PR DESCRIPTION
### What was wrong?
eth-tester was pinned to use the Byzantium vm rules, which are not compatible with newer versions of solidity. Updated to use the Constantinople vm rules by default. 

See [this issue](https://github.com/ethereum/py-evm/issues/1748)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/56034314-4be64280-5d27-11e9-8be3-0144d13e603b.png)