### PR TITLE
Upgrade to py-evm v0.2.0-alpha.43

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.2.0a42",
+        "py-evm==0.2.0a43",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

related to #157 

### How was it fixed?

It's not, just showing what the tasks are for upgrading. For example, stop referencing `account_db` directly, and use vm state, like: `vm.state.get_balance(acct)` instead of `vm.state.account_db.get_balance(acct)`

#### Cute Animal Picture

![Cute animal picture]()
