### PR TITLE
Default py-evm backend VM to Istanbul

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Unreleased
 ----------
 
+- Breaking changes
+
+  - Default to IstanbulVM
+    https://github.com/ethereum/eth-tester/pull/169
+
 - Misc
 
   - Upgrade to py-evm v0.3.0-b7

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -147,17 +147,17 @@ def get_default_genesis_params(overrides=None):
 def setup_tester_chain(genesis_params=None, genesis_state=None, num_accounts=None):
     from eth.chains.base import MiningChain
     from eth.db import get_db_backend
-    from eth.vm.forks.constantinople import ConstantinopleVM
+    from eth.vm.forks.istanbul import IstanbulVM
 
-    class ConstantinopleNoProofVM(ConstantinopleVM):
-        """Constantinople VM rules, without validating any miner proof of work"""
+    class IstanbulNoProofVM(IstanbulVM):
+        """Istanbul VM rules, without validating any miner proof of work"""
 
         @classmethod
         def validate_seal(self, header):
             pass
 
     class MainnetTesterNoProofChain(MiningChain):
-        vm_configuration = ((0, ConstantinopleNoProofVM), )
+        vm_configuration = ((0, IstanbulNoProofVM), )
 
         @classmethod
         def validate_seal(cls, block):


### PR DESCRIPTION
### What was wrong?

eth-tester was defaulting to Constantinople (not even St Petersburg!)

### How was it fixed?

Default to Istanbul

#### Cute Animal Picture

![Cute animal picture](https://www.moshimoshi-nippon.jp/wp/wp-content/uploads/2018/03/Animo.jpg)