### PR TITLE
py-evm expects the block header, not the hash, as of v0.3.0-alpha.11.

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -304,7 +304,7 @@ class PyEVMBackend(BaseChainBackend):
         block = self.chain.get_block_by_hash(snapshot)
         chaindb = self.chain.chaindb
 
-        chaindb._set_as_canonical_chain_head(chaindb.db, block.header.hash, GENESIS_PARENT_HASH)
+        chaindb._set_as_canonical_chain_head(chaindb.db, block.header, GENESIS_PARENT_HASH)
         if block.number > 0:
             self.chain.import_block(block)
         else:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.3.0a8",
+        "py-evm==0.3.0a11",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

Incompatibility with py-evm by dint of the backend.  Here's an example traceback: https://gist.github.com/jMyles/4a32dff65edf5b5b22ecbe4e24c24d70

The change to py-evm which caused this API modification is here: https://github.com/ethereum/py-evm/commit/bfdcf12fce8f2827ed802ec73bdb351ac99a5f8d

### How was it fixed?

By passing the full header instead of just the hash.

#### Cute Animal Picture
![9aum5dcwzp441](https://user-images.githubusercontent.com/311973/70860083-cd532d80-1ed1-11ea-9ffc-21a7aeecc6ba.jpg)


