### PR TITLE
Default py-evm backend VM to Muir Glacier

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -147,17 +147,17 @@ def get_default_genesis_params(overrides=None):
 def setup_tester_chain(genesis_params=None, genesis_state=None, num_accounts=None):
     from eth.chains.base import MiningChain
     from eth.db import get_db_backend
-    from eth.vm.forks.istanbul import IstanbulVM
+    from eth.vm.forks.muir_glacier import MuirGlacierVM
 
-    class IstanbulNoProofVM(IstanbulVM):
-        """Istanbul VM rules, without validating any miner proof of work"""
+    class MuirGlacierNoProofVM(MuirGlacierVM):
+        """Muir Glacier VM rules, without validating any miner proof of work"""
 
         @classmethod
         def validate_seal(self, header):
             pass
 
     class MainnetTesterNoProofChain(MiningChain):
-        vm_configuration = ((0, IstanbulNoProofVM), )
+        vm_configuration = ((0, MuirGlacierNoProofVM), )
 
         @classmethod
         def validate_seal(cls, block):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.3.0a11",
+        "py-evm==0.3.0a12",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

Istanbul fork was still used.

### How was it fixed?

Update to Muir Glacier. As nothing but the ice age delay changed this shouldn't cause trouble.

#### Cute Animal Picture

![Cute animal picture](https://upload.wikimedia.org/wikipedia/commons/thumb/9/90/Haselmaus_%28cropped_2%29.jpg/250px-Haselmaus_%28cropped_2%29.jpg)
