### PR TITLE
docs: time-travel note about needing to mine

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The chain can only time travel forward in time.
 The `timestamp` must be an integer, strictly greater than the current timestamp
 of the latest block.  
 
-> Note: Time traveling will result in a new block being mined.
+> Note: You must mine a block before time traveling will take effect. See https://github.com/ethereum/eth-tester/issues/154 for discussion about improving this functionality.
 
 
 ### Mining


### PR DESCRIPTION
### What was wrong?

#154 -- docs say that time traveling immediately results in a new block being mined. It does not.

### How was it fixed?

Updated the docs. (Later, it's the functionality that should change)

#### Cute Animal Picture

![Cute animal picture](https://archive.content.aah.net.au/files/images/cat-with-alarm-clock.jpg)
