### PR TITLE
Upgrade eth-keys for updated eth-typing usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 Unreleased
 -------------
 
-None
+- Misc
+
+  - Upgrate eth-keys to allow 0.3.* versions
 
 v0.4.0-beta.1
 -------------

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=2.0.0b4,<3.0.0",
-        "eth-keys>=0.2.1,<0.3.0",
+        "eth-keys>=0.2.1,<0.4.0",
         "eth-utils>=1.4.1,<2.0.0",
         "rlp>=1.1.0,<2.0.0",
         "semantic_version>=2.6.0,<3.0.0",


### PR DESCRIPTION
Permit older eth-keys as we have other libraries that still constrain to
<v0.3 for now.

### What was wrong?

eth-keys was constrained to `0.2.*`, and we want `0.3.*` to get rid of deprecation warnings.

### How was it fixed?

Update the setup file.

#### Cute Animal Picture

![Cute animal picture](https://www.oddee.com/wp-content/uploads/_media/imgs/articles2/a99412_animal-hug_2-teddy-bear.jpg)
