### PR TITLE
Stop masking Revert error as TransactionFailed

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -464,7 +464,7 @@ class PyEVMBackend(BaseChainBackend):
 
     @replace_exceptions({
         EVMInvalidInstruction: TransactionFailed,
-        EVMRevert: TransactionFailed})
+    })
     def estimate_gas(self, transaction):
         evm_transaction = self._get_normalized_and_unsigned_evm_transaction(assoc(
             transaction, 'gas', 21000))

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -51,6 +51,11 @@ from .throws_contract import (
     _make_call_throws_transaction,
     _decode_throws_result,
 )
+from eth_tester.backends.pyevm.utils import is_pyevm_available
+if is_pyevm_available():
+    from eth.exceptions import (
+        Revert as EVMRevert,
+    )
 
 
 PK_A = '0x58d23b55bc9cdce1f18c2500f40ff4ab7245df9a89505e9b1fa4851f623d241d'
@@ -719,7 +724,7 @@ class BaseTestBackendDirect:
             'throw_contract',
             'willThrow',
         )
-        with pytest.raises(TransactionFailed):
+        with pytest.raises(EVMRevert):
             eth_tester.estimate_gas(dissoc(call_will_throw_transaction, 'gas'))
 
         call_set_value_transaction = _make_call_throws_transaction(


### PR DESCRIPTION
### What was wrong?
Original issue is [here](https://github.com/ethereum/web3.py/issues/941).

I'm not sure what the original rationale was, but the `Revert` error was getting turned into a `TransactionFailed` error. I want to test that Revert is raised in web3.py in [this PR](https://github.com/ethereum/web3.py/pull/1585).

This is my first PR in eth-tester, so I'm not sure if there is something else that I need to do in py-evm, or what sorts of unintended consequences there will be in other libraries as this is a breaking change. 

### How was it fixed?
Removed `TransactionFailed` from the decorator that replaces exceptions. 

#### Cute Animal Picture

<img width="239" alt="image" src="https://user-images.githubusercontent.com/6540608/75200016-e2dea200-5721-11ea-8537-143b87a6fe57.png">

