### PR TITLE
Add block_hash parameter to get_logs and create_log_filter.

### DIFF
--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -556,23 +556,26 @@ class EthereumTester:
         filter_id = self.normalizer.normalize_outbound_filter_id(raw_filter_id)
         return filter_id
 
-    def create_log_filter(self, from_block=None, to_block=None, address=None, topics=None):
+    def create_log_filter(self, from_block=None, to_block=None, address=None, topics=None, block_hash=None):
         self.validator.validate_inbound_filter_params(
             from_block=from_block,
             to_block=to_block,
             address=address,
             topics=topics,
+            block_hash=block_hash,
         )
         (
             raw_from_block,
             raw_to_block,
             raw_address,
             raw_topics,
+            raw_block_hash,
         ) = self.normalizer.normalize_inbound_filter_params(
             from_block=from_block,
             to_block=to_block,
             address=address,
             topics=topics,
+            block_hash=block_hash,
         )
 
         raw_filter_id = next(self._filter_counter)
@@ -581,6 +584,7 @@ class EthereumTester:
             'to_block': raw_to_block,
             'addresses': raw_address,
             'topics': raw_topics,
+            'block_hash': raw_block_hash,
         }
         filter_fn = partial(
             check_if_log_matches,
@@ -658,23 +662,26 @@ class EthereumTester:
             yield normalize_fn(item)
 
     @to_tuple
-    def get_logs(self, from_block=None, to_block=None, address=None, topics=None):
+    def get_logs(self, from_block=None, to_block=None, address=None, topics=None, block_hash=None):
         self.validator.validate_inbound_filter_params(
             from_block=from_block,
             to_block=to_block,
             address=address,
             topics=topics,
+            block_hash=block_hash,
         )
         (
             raw_from_block,
             raw_to_block,
             raw_address,
             raw_topics,
+            raw_block_hash
         ) = self.normalizer.normalize_inbound_filter_params(
             from_block=from_block,
             to_block=to_block,
             address=address,
             topics=topics,
+            block_hash=block_hash
         )
 
         # Setup the filter object
@@ -683,6 +690,7 @@ class EthereumTester:
             'to_block': raw_to_block,
             'addresses': raw_address,
             'topics': raw_topics,
+            'block_hash': raw_block_hash,
         }
         filter_fn = partial(
             check_if_log_matches,

--- a/eth_tester/normalization/base.py
+++ b/eth_tester/normalization/base.py
@@ -14,7 +14,7 @@ class BaseNormalizer:
     def normalize_inbound_filter_id(self, filter_id):
         raise NotImplementedError("must be implemented by subclasses")
 
-    def normalize_inbound_filter_params(self, from_block, to_block, address, topics):
+    def normalize_inbound_filter_params(self, from_block, to_block, address, topics, block_hash):
         raise NotImplementedError("must be implemented by subclasses")
 
     def normalize_inbound_log_entry(self, log_entry):

--- a/eth_tester/normalization/inbound.py
+++ b/eth_tester/normalization/inbound.py
@@ -41,7 +41,7 @@ def normalize_topic_list(topics):
 
 
 @to_tuple
-def normalize_filter_params(from_block, to_block, address, topics):
+def normalize_filter_params(from_block, to_block, address, topics, block_hash):
     yield from_block
     yield to_block
 
@@ -70,6 +70,7 @@ def normalize_filter_params(from_block, to_block, address, topics):
         )
     else:
         raise TypeError(f"Topics are not in a recognized format: {address}")
+    yield block_hash
 
 
 def normalize_private_key(value):

--- a/eth_tester/utils/filters.py
+++ b/eth_tester/utils/filters.py
@@ -122,6 +122,13 @@ def check_if_to_block_match(block_number, _type, to_block):
         raise ValueError(f"Unrecognized to_block format: {to_block}")
 
 
+def check_if_block_hash_match(log_block_hash, target_block_hash):
+    if target_block_hash is None:
+        return True
+    else:
+        return  log_block_hash == target_block_hash
+
+
 def check_if_log_matches_flat_topics(log_topics, filter_topics):
     if not filter_topics:
         return True
@@ -173,7 +180,8 @@ def check_if_log_matches(log_entry,
                          from_block,
                          to_block,
                          addresses,
-                         topics):
+                         topics,
+                         block_hash,):
     if not check_if_from_block_match(log_entry['block_number'], log_entry['type'], from_block):
         return False
     elif not check_if_to_block_match(log_entry['block_number'], log_entry['type'], to_block):
@@ -181,6 +189,8 @@ def check_if_log_matches(log_entry,
     elif not check_if_address_match(log_entry['address'], addresses):
         return False
     elif not check_if_topics_match(log_entry['topics'], topics):
+        return False
+    elif not check_if_block_hash_match(log_entry['block_hash'], block_hash):
         return False
     else:
         return True

--- a/eth_tester/validation/base.py
+++ b/eth_tester/validation/base.py
@@ -17,7 +17,7 @@ class BaseValidator:
     def validate_inbound_filter_id(self, filter_id):
         raise NotImplementedError("must be implemented by subclasses")
 
-    def validate_inbound_filter_params(self, from_block, to_block, address, topics):
+    def validate_inbound_filter_params(self, from_block, to_block, address, topics, block_hash):
         raise NotImplementedError("must be implemented by subclasses")
 
     def validate_inbound_private_key(self, private_key):

--- a/eth_tester/validation/inbound.py
+++ b/eth_tester/validation/inbound.py
@@ -105,12 +105,16 @@ def is_valid_topic_array(value):
         for item in value)
 
 
-def validate_filter_params(from_block, to_block, address, topics):
+def validate_filter_params(from_block, to_block, address, topics, block_hash):
     # blocks
     if from_block is not None:
         validate_block_number(from_block)
     if to_block is not None:
         validate_block_number(to_block)
+    if block_hash is not None:
+        validate_block_hash(block_hash)
+    if block_hash is not None and (from_block is not None or to_block is not None):
+        raise ValidationError("When filtering by block hash, neither from block nor to block can be set.")
 
     # address
     if address is None:

--- a/tests/core/filter-utils/test_filter_helpers.py
+++ b/tests/core/filter-utils/test_filter_helpers.py
@@ -25,6 +25,8 @@ TOPIC_A = b'\x00' * 32
 TOPIC_B = b'\x00' * 31 + b'\x01'
 TOPIC_C = b'\x00' * 31 + b'\x02'
 
+BLOCK_HASH = b'\x01' * 32
+
 
 def topic_to_name(param):
     if is_list_like(param):
@@ -438,9 +440,10 @@ def test_check_if_address_match(address, addresses, expected):
     assert actual is expected
 
 
-def _make_log(block_number=10, topics=None, address=ADDRESS_A, _type='mined', **kwargs):
+def _make_log(block_number=10, topics=None, address=ADDRESS_A, _type='mined', block_hash=None, **kwargs):
     return dict(
         block_number=block_number,
+        block_hash=block_hash,
         topics=topics or tuple(),
         address=address,
         type=_type,
@@ -448,12 +451,13 @@ def _make_log(block_number=10, topics=None, address=ADDRESS_A, _type='mined', **
     )
 
 
-def _make_filter(from_block=None, to_block=None, topics=None, addresses=None):
+def _make_filter(from_block=None, to_block=None, topics=None, addresses=None, block_hash=None):
     return {
         'from_block': from_block,
         'to_block': to_block,
         'topics': topics,
         'addresses': addresses,
+        'block_hash': block_hash,
     }
 
 
@@ -467,6 +471,9 @@ def _make_filter(from_block=None, to_block=None, topics=None, addresses=None):
         (_make_log(block_number=30), _make_filter(from_block=10, to_block=20), False),
         (_make_log(block_number=30), _make_filter(to_block=20), False),
         (_make_log(block_number=20), _make_filter(to_block=20), True),
+        # block hash
+        (_make_log(block_hash=BLOCK_HASH), _make_filter(block_hash=BLOCK_HASH), True),
+        (_make_log(block_hash=BLOCK_HASH), _make_filter(block_hash=TOPIC_A), False),
         # topics
         (_make_log(topics=(TOPIC_A,)), _make_filter(topics=FILTER_MATCH_ALL), True),
         (_make_log(topics=(TOPIC_A, TOPIC_B)), _make_filter(topics=FILTER_MATCH_ALL), True),

--- a/tests/core/validation/test_inbound_validation.py
+++ b/tests/core/validation/test_inbound_validation.py
@@ -100,12 +100,13 @@ def test_block_hash_input_validation(validator, block_hash, is_valid):
             validator.validate_inbound_block_hash(block_hash)
 
 
-def _make_filter_params(from_block=None, to_block=None, address=None, topics=None):
+def _make_filter_params(from_block=None, to_block=None, address=None, topics=None, block_hash=None):
     return {
         'from_block': from_block,
         'to_block': to_block,
         'address': address,
         'topics': topics,
+        'block_hash': block_hash,
     }
 
 
@@ -135,12 +136,14 @@ ADDRESS_A = encode_hex(b'\x00' * 19 + b'\x01')
 ADDRESS_B = encode_hex(b'\x00' * 19 + b'\x02')
 TOPIC_A = encode_hex(b'\x00' * 31 + b'\x01')
 TOPIC_B = encode_hex(b'\x00' * 31 + b'\x02')
+BLOCK_HASH = encode_hex(b'\x01' * 32)
 
 
 @pytest.mark.parametrize(
     "filter_params,is_valid",
     (
         (_make_filter_params(), True),
+        # block numbers
         (_make_filter_params(from_block=0), True),
         (_make_filter_params(to_block=0), True),
         (_make_filter_params(from_block=-1), False),
@@ -151,12 +154,19 @@ TOPIC_B = encode_hex(b'\x00' * 31 + b'\x02')
         (_make_filter_params(to_block='0x0'), False),
         (_make_filter_params(from_block='0x1'), False),
         (_make_filter_params(to_block='0x1'), False),
+        # block hash
+        (_make_filter_params(block_hash=BLOCK_HASH), True),
+        (_make_filter_params(block_hash=''), False),
+        (_make_filter_params(block_hash=b'\x01' * 32), False),
+        (_make_filter_params(block_hash=encode_hex(b'\x01' * 31)), False),
+        # address
         (_make_filter_params(address=ADDRESS_A), True),
         (_make_filter_params(address=decode_hex(ADDRESS_A)), False),
         (_make_filter_params(address=[ADDRESS_A, ADDRESS_B]), True),
         (_make_filter_params(address=TOPIC_A), False),
         (_make_filter_params(address=decode_hex(TOPIC_A)), False),
         (_make_filter_params(address=[TOPIC_A, ADDRESS_B]), False),
+        # topics
         (_make_filter_params(topics=[TOPIC_A]), True),
         (_make_filter_params(topics=[TOPIC_A, TOPIC_B]), True),
         (_make_filter_params(topics=[TOPIC_A, None]), True),


### PR DESCRIPTION
This parameter can be used to filter the returned logs based on block
hash in accordance to https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getLogs

### What was wrong?



### How was it fixed?



#### Cute Animal Picture

![Cute animal picture]()
