### PR TITLE
Upgrade py evm

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Unreleased
 - Misc
 
   - Upgrate eth-keys to allow 0.3.* versions
+  - Upgrate py-evm to v0.3.0-alpha.15, which allows the eth-keys upgrade
 
 v0.4.0-beta.1
 -------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.3.0a12",
+        "py-evm==0.3.0a15",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
Current impetus is eth-keys flexibility. Hooray for having py-evm not break any APIs! :)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/600x315/62/73/39/627339fc0ffb6964467285dba388fd60.jpg)
