### PR TITLE
Update PR template to nudge changelog addition

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,10 @@
 
 
 
+### To-Do:
+
+- [ ] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)
+
 #### Cute Animal Picture
 
 ![Cute animal picture]()


### PR DESCRIPTION
### What was wrong?
Referenced the CHANGELOG to make versioning decisions for web3.py, but it doesn't reflect all changes.

### How was it fixed?
At least nudge contributors to update the changelog each PR.


#### Cute Animal Picture

![](https://www.liveabout.com/thmb/ECCz8YXsUoILmz368oO3uKZSsSQ=/768x0/filters:no_upscale():max_bytes(150000):strip_icc()/cat-couch-59775c3f519de2001197a925.jpg)
