### PR TITLE
support gas estimates with block identifier

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 Unreleased
 -------------
 
-None
+- Features
+
+	- Add support for gas estimate block identifiers
 
 v0.4.0-beta.2
 -------------

--- a/eth_tester/backends/base.py
+++ b/eth_tester/backends/base.py
@@ -91,7 +91,7 @@ class BaseChainBackend(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @abstractmethod
-    def estimate_gas(self, transaction):
+    def estimate_gas(self, transaction, block_number="latest"):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @abstractmethod

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -428,10 +428,12 @@ class EthereumTester:
         result = self.normalizer.normalize_outbound_return_data(raw_result)
         return result
 
-    def estimate_gas(self, transaction):
+    def estimate_gas(self, transaction, block_number="latest"):
         self.validator.validate_inbound_transaction(transaction, txn_type='estimate')
         raw_transaction = self.normalizer.normalize_inbound_transaction(transaction)
-        raw_gas_estimate = self.backend.estimate_gas(raw_transaction)
+        self.validator.validate_inbound_block_number(block_number)
+        raw_block_number = self.normalizer.normalize_inbound_block_number(block_number)
+        raw_gas_estimate = self.backend.estimate_gas(raw_transaction, raw_block_number)
         self.validator.validate_outbound_gas_estimate(raw_gas_estimate)
         gas_estimate = self.normalizer.normalize_outbound_gas_estimate(raw_gas_estimate)
         return gas_estimate

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -686,6 +686,21 @@ class BaseTestBackendDirect:
         # https://github.com/ethereum/py-evm/blob/f0276e684edebd7cd9e84cd04b3229ab9dd958b9/evm/estimators/__init__.py#L11
         assert receipt['gas_used'] >= gas_estimation - 21000
 
+    def test_estimate_gas_with_block_identifier(self, eth_tester):
+        self.skip_if_no_evm_execution()
+
+        math_address = _deploy_math(eth_tester)
+        estimate_call_math_transaction = _make_call_math_transaction(
+            eth_tester, math_address, "increment",
+        )
+        latest_gas_estimation = eth_tester.estimate_gas(
+            estimate_call_math_transaction, "latest"
+        )
+        earliest_gas_estimation = eth_tester.estimate_gas(
+            estimate_call_math_transaction, "earliest"
+        )
+        assert latest_gas_estimation != earliest_gas_estimation
+
     def test_can_call_after_exception_raised_calling(self, eth_tester):
         self.skip_if_no_evm_execution()
 


### PR DESCRIPTION
### What was wrong?

Re: https://github.com/ethereum/web3.py/pull/1639, py-evm supports gas estimation with block identifiers, but eth-tester didn't yet pass those values through.

### How was it fixed?

`estimate_gas` now accepts and processes a `block_number`.

Feedback appreciated @carver (and anyone else interested); I processed the minimum surface area of this package required to get this far and get passing tests on the [Web3 side](https://github.com/ethereum/web3.py/pull/1639).

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![](https://static.smalljoys.me/2018/12/19-5.jpg)
