### PR TITLE
Allow `py-evm` backend to use a custom VM

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@ Unreleased
 
 - Features
 
-	- Add support for gas estimate block identifiers
+  - Add support for gas estimate block identifiers
+  - Add support for custom virtual machine fork schedule in PyEVMBackend
 
 v0.4.0-beta.2
 -------------


### PR DESCRIPTION
### What was wrong?

The `py-evm` backend was hardcoded to use the latest VM ruleset. This makes it difficult to experiment with or test future forks using this library.

### How was it fixed?

A custom VM class can now be passed to the `py-evm` backend constructor.

#### Cute Animal Picture

![Cute animal picture](https://www.cuded.com/wp-content/uploads/2011/11/4600_4001.jpg)
