### PR TITLE
Upgrade rlp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
   py36-pyevm:
     <<: *common
     docker:
@@ -70,6 +76,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-pyevm
+  py38-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-pyevm
 
 workflows:
   version: 2
@@ -78,5 +90,7 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core
       - py36-pyevm
       - py37-pyevm
+      - py38-pyevm

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 Unreleased
 -------------
 
-None
+- Performance
+
+  - Upgrade pyrlp to v2-alpha1, with faster encoding/decoding
+    https://github.com/ethereum/eth-tester/pull/195
 
 
 v0.5.0-beta.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Unreleased
 -------------
 
+- Features
+
+  - Officially support py3.8
+    https://github.com/ethereum/eth-tester/pull/195
+
 - Performance
 
   - Upgrade pyrlp to v2-alpha1, with faster encoding/decoding

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,12 @@ Unreleased
   - Upgrade pyrlp to v2-alpha1, with faster encoding/decoding
     https://github.com/ethereum/eth-tester/pull/195
 
+- Misc
+
+  - Pypy support completely dropped (it was never officially added,
+    only some pieces were tested, in hopes of eventually supporting)
+    https://github.com/ethereum/eth-tester/pull/195
+
 
 v0.5.0-beta.1
 -------------

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "eth-abi>=2.0.0b4,<3.0.0",
         "eth-keys>=0.2.1,<0.4.0",
         "eth-utils>=1.4.1,<2.0.0",
-        "rlp>=1.1.0,<2.0.0",
+        "rlp>=1.1.0,<=2.0.0-alpha.1",
         "semantic_version>=2.6.0,<3.0.0",
     ],
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist=
-    py{36,37,py3}-{core}
-    py{36,37}-{pyevm}
+    py{36,37}-{core,pyevm}
     lint
 
 [flake8]
@@ -11,14 +10,13 @@ exclude= tests/*
 [testenv]
 usedevelop=True
 commands=
-    core: py.test {posargs:tests/core}
-    pyevm: py.test {posargs:tests/backends/test_pyevm.py}
+    core: pytest {posargs:tests/core}
+    pyevm: pytest {posargs:tests/backends/test_pyevm.py}
 deps =
     coincurve>=6.0.0
 basepython =
     py36: python3.6
     py37: python3.7
-    pypy3: pypy3
 extras =
     test
     pyevm: py-evm

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-{core,pyevm}
+    py{36,37,38}-{core,pyevm}
     lint
 
 [flake8]
@@ -17,6 +17,7 @@ deps =
 basepython =
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 extras =
     test
     pyevm: py-evm


### PR DESCRIPTION
### What was wrong?

Wanted to support latest rlp. See ethereum/trinity#2004

### How was it fixed?

- Allow latest pyrlp version
- Drop all tox tests for pypy (not compatible with pyrlp)
- Add tests for py3.8


### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/a7/30/6a/a7306a06325687c7a43537d622578a49.jpg)