### PR TITLE
Upgrade py-evm to v0.3.0-alpha.19

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@ Unreleased
   - Pypy support completely dropped (it was never officially added,
     only some pieces were tested, in hopes of eventually supporting)
     https://github.com/ethereum/eth-tester/pull/195
+  - Upgrade to pyevm v0.3.0-alpha.19
+    https://github.com/ethereum/eth-tester/pull/196
 
 
 v0.5.0-beta.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.3.0a15",
+        "py-evm==0.3.0a19",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

Using old py-evm

### How was it fixed?

Upgrade it to v0.3.0-alpha.19

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![Cute animal picture](https://ak.picdn.net/shutterstock/videos/34823395/thumb/1.jpg)