### PR TITLE
Update pinned py-evm version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.3.0a19",
+        "py-evm==0.3.0a20",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?
Updated `py-evm` version is needed for compatibility with `rlp==2.0.0`


### How was it fixed?
Pinned new `py-evm` version in `setup.py`

### To-Do:

- [ ] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/97156970-73540300-1745-11eb-87ca-33ec5f0524fc.png)

