### PR TITLE
Update py-evm for Berlin support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,11 @@
 Unreleased
 -------------
 
-None
+- Features
+
+  - Upgrade py-evm to v0.4.0-alpha.3, for Berlin support
+    https://github.com/ethereum/eth-tester/pull/204
+
 
 v0.5.0-beta.2
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Unreleased
 - Features
 
   - Upgrade py-evm to v0.4.0-alpha.3, for Berlin support
+    Default to Berlin
     https://github.com/ethereum/eth-tester/pull/204
 
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -156,8 +156,8 @@ def setup_tester_chain(
     from eth.db import get_db_backend
 
     if vm_configuration is None:
-        from eth.vm.forks.muir_glacier import MuirGlacierVM
-        no_proof_vms = ((0, MuirGlacierVM.configure(consensus_class=NoProofConsensus)),)
+        from eth.vm.forks import BerlinVM
+        no_proof_vms = ((0, BerlinVM.configure(consensus_class=NoProofConsensus)),)
     else:
         consensus_applier = ConsensusApplier(NoProofConsensus)
         no_proof_vms = consensus_applier.amend_vm_configuration(vm_configuration)

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import time
 
-import rlp
-
 from eth_abi import (
     decode_single
 )
@@ -107,7 +105,7 @@ def get_default_account_state(overrides=None):
 def get_default_account_keys(quantity=None):
     keys = KeyAPI()
     quantity = quantity or 10
-    for i in range(1, quantity+1):
+    for i in range(1, quantity + 1):
         pk_bytes = int_to_big_endian(i).rjust(32, b'\x00')
         private_key = keys.PrivateKey(pk_bytes)
         yield private_key
@@ -461,8 +459,7 @@ class PyEVMBackend(BaseChainBackend):
 
     def send_raw_transaction(self, raw_transaction):
         vm = _get_vm_for_block_number(self.chain, "latest")
-        TransactionClass = vm.get_transaction_class()
-        evm_transaction = rlp.decode(raw_transaction, TransactionClass)
+        evm_transaction = vm.get_transaction_builder().decode(raw_transaction)
         self.chain.apply_transaction(evm_transaction)
         return evm_transaction.hash
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -284,9 +284,16 @@ class BaseTestBackendDirect:
         # assert that the raw transaction is confirmed and successful
         assert receipt['transaction_hash'] == transaction_hash
 
-    def test_send_raw_transaction_invalid_raw_transaction(self, eth_tester):
+    def test_send_raw_transaction_invalid_rlp_transaction(self, eth_tester):
         self.skip_if_no_evm_execution()
         invalid_transaction_hex = '0x1234'
+        import eth
+        with pytest.raises(eth.exceptions.UnrecognizedTransactionType):
+            eth_tester.send_raw_transaction(invalid_transaction_hex)
+
+    def test_send_raw_transaction_invalid_raw_transaction(self, eth_tester):
+        self.skip_if_no_evm_execution()
+        invalid_transaction_hex = '0xffff'
         with pytest.raises(rlp.exceptions.DecodingError):
             eth_tester.send_raw_transaction(invalid_transaction_hex)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.3.0a20",
+        "py-evm==0.4.0a3",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import pytest
 from eth.vm.forks import (
     FrontierVM,
-    MuirGlacierVM,
+    BerlinVM,
 )
 from eth_utils import to_wei
 
@@ -35,17 +35,17 @@ def test_custom_virtual_machines():
 
     backend = PyEVMBackend(vm_configuration=(
         (0, FrontierVM),
-        (3, MuirGlacierVM),
+        (3, BerlinVM),
     ))
 
     # This should be a FrontierVM block
     VM_at_2 = backend.chain.get_vm_class_for_block_number(2)
-    # This should be a MuirGlacier block
+    # This should be a BerlinVM block
     VM_at_3 = backend.chain.get_vm_class_for_block_number(3)
 
     assert issubclass(VM_at_2, FrontierVM)
-    assert not issubclass(VM_at_2, MuirGlacierVM)
-    assert issubclass(VM_at_3, MuirGlacierVM)
+    assert not issubclass(VM_at_2, BerlinVM)
+    assert issubclass(VM_at_3, BerlinVM)
 
     # Right now, just test that EthereumTester doesn't crash
     # Maybe some more sophisticated test to make sure the VMs are set correctly?


### PR DESCRIPTION
### What was wrong?

Using a pre-Berlin evm.

### How was it fixed?

Update py-evm. Set default VM to Berlin. Resolve a couple changed APIs.

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![Cute animal picture](https://blog.mystart.com/wp-content/uploads/shutterstock_262571516-e1520615420194.jpg)
