### PR TITLE
add python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
   py36-pyevm:
     <<: *common
     docker:
@@ -82,6 +88,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-pyevm
+  py39-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-pyevm
 
 workflows:
   version: 2
@@ -91,6 +103,8 @@ workflows:
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
       - py36-pyevm
       - py37-pyevm
       - py38-pyevm
+      - py39-pyevm

--- a/.gitignore
+++ b/.gitignore
@@ -100,5 +100,8 @@ fabric.properties
 # virtualenv directories
 venv*
 
+# pyenv-virtualenv
+.python-version
+
 # VIM
 *.swp

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ Unreleased
 
 - Features
 
+	- Upgrade py-evm to v0.4.0-alpha.4 for Python 3.9 support
+		https://github.com/ethereum/eth-tester/pull/205
   - Upgrade py-evm to v0.4.0-alpha.3, for Berlin support
     Default to Berlin
     https://github.com/ethereum/eth-tester/pull/204

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.4.0a3",
+        "py-evm==0.4.0a4",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],
@@ -74,5 +74,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,38}-{core,pyevm}
+    py{36,37,38,39}-{core,pyevm}
     lint
 
 [flake8]
@@ -18,6 +18,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 extras =
     test
     pyevm: py-evm


### PR DESCRIPTION
### What was wrong?

A py-evm update is required to bring eth-tester and web3.py (https://github.com/ethereum/web3.py/issues/1769) into the 3.9 age.

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRaHRsiCtlPrgQHmniKhxBzpWSAR_l5-i8QWYwlEV4EApFVJXzmkG_1iG7jMWwAnI8KPCQ&usqp=CAU)
