### PR TITLE
fix: use correct word

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+Unreleased
+-------------
+
+- Misc
+
+  - Adjust wording in README regarding genesis parameters
+
 v0.5.0-beta.4
 -------------
 Released 2021-04-12

--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ Then pass the generated `custom_genesis_params` `dict` to the backend's `__init_
 ```
 
 Overriding genesis state is similar to overriding genesis parameters but requires the consideration of test accounts.
-To override the genesis state of accounts, pass a `state_overrides` `dict` to `PyEVM.generate_genesis_state`,
+To override the genesis state of accounts, pass a `state_overrides` `dict` to `PyEVMBackend._generate_genesis_state`,
 and optionally, the number of accounts to create.  
 
 *NOTE: The same state is applied to all generated test accounts.* 

--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ Then pass the generated `custom_genesis_params` `dict` to the backend's `__init_
 >>> t = EthereumTester(backend=pyevm_backend)
 ```
 
-Overriding genesis state is similar to overriding genesis state, but requires the consideration of test accounts.
+Overriding genesis state is similar to overriding genesis parameters but requires the consideration of test accounts.
 To override the genesis state of accounts, pass a `state_overrides` `dict` to `PyEVM.generate_genesis_state`,
 and optionally, the number of accounts to create.  
 


### PR DESCRIPTION
### What was wrong?

README had a confusing sentence

### How was it fixed?

Use the word that was probably meant to be used in the readme.

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![baby_moose](https://user-images.githubusercontent.com/19540978/139458960-3f407961-1dd2-406d-ad97-1bca18e6438b.jpeg)
)
