### PR TITLE
feat: support mnemonic when generating genesis accounts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,14 @@
 Unreleased
 -------------
 
+- Features
+
+  - Support for custom mnemonic when initializing the Backend for EthTester
+
 - Misc
 
   - Adjust wording in README regarding genesis parameters
+
 
 v0.5.0-beta.4
 -------------

--- a/README.md
+++ b/README.md
@@ -817,9 +817,25 @@ Then pass the generated `custom_genesis_params` `dict` to the backend's `__init_
 >>> t = EthereumTester(backend=pyevm_backend)
 ```
 
-Overriding genesis state is similar to overriding genesis parameters but requires the consideration of test accounts.
-To override the genesis state of accounts, pass a `state_overrides` `dict` to `PyEVMBackend._generate_genesis_state`,
-and optionally, the number of accounts to create.  
+Similarly to `genesis_parameters`, override the genesis state by passing in an `overrides` `dict`
+to `PyEVMBackend._generate_genesis_state`. Optionally, provide `num_accounts` to set the number of accounts.
+
+For more control on which accounts the backend generates, use the `from_mnemonic()` classmethod. Give it
+a `mnemonic` (and optionally the number of accounts) and it will use that information to generate the accounts.
+Optionally, provide a `genesis_state_overrides` to adjust the `genesis_state`.
+```python
+>>> from eth_tester import PyEVMBackend, EthereumTester
+>>> from eth_utils import to_wei
+>>> from hexbytes import HexBytes
+>>>
+>>> pyevm_backend = PyEVMBackend.from_mnemonic(
+>>>    'test test test test test test test test test test test junk',
+>>>    genesis_state_overrides={'balance': to_wei(1000000, 'ether')}
+>>> )
+>>> t = EthereumTester(backend=pyevm_backend)
+>>> print(t.get_accounts()[0])  # Outputs 0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C
+>>> print(t.get_balance('0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C'))  # Outputs 1000000000000000000000000
+```
 
 *NOTE: The same state is applied to all generated test accounts.* 
 

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ to `PyEVMBackend._generate_genesis_state`. Optionally, provide `num_accounts` to
 
 For more control on which accounts the backend generates, use the `from_mnemonic()` classmethod. Give it
 a `mnemonic` (and optionally the number of accounts) and it will use that information to generate the accounts.
-Optionally, provide a `genesis_state_overrides` to adjust the `genesis_state`.
+Optionally, provide a `genesis_state_overrides` `dict` to adjust the `genesis_state`.
 ```python
 >>> from eth_tester import PyEVMBackend, EthereumTester
 >>> from eth_utils import to_wei

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=2.0.0b4,<3.0.0",
+        "eth-account==0.5.6",
         "eth-keys>=0.2.1,<0.4.0",
         "eth-utils>=1.4.1,<2.0.0",
         "rlp>=1.1.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=2.0.0b4,<3.0.0",
-        "eth-account==0.5.6",
+        "eth-account>=0.5.6,<0.6.0",
         "eth-keys>=0.2.1,<0.4.0",
         "eth-utils>=1.4.1,<2.0.0",
         "rlp>=1.1.0,<3",

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -19,6 +19,7 @@ from eth_tester.utils.backend_testing import BaseTestBackendDirect, SIMPLE_TRANS
 
 
 ZERO_ADDRESS_HEX = "0x0000000000000000000000000000000000000000"
+MNEMONIC = "test test test test test test test test test test test junk"
 
 
 @pytest.fixture
@@ -119,6 +120,34 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
             account = private_key.public_key.to_checksum_address()
             balance = tester.get_balance(account=account)
             assert balance == state_overrides["balance"]
+
+    def test_from_mnemonic(self):
+        # Initialize PyEVM backend using MNEMONIC, num_accounts,
+        # and state overrides (balance)
+        num_accounts = 3
+        balance = to_wei(15, "ether")  # Give each account 15 Eth
+        pyevm_backend = PyEVMBackend.from_mnemonic(
+            MNEMONIC, num_accounts=num_accounts, genesis_state_overrides={"balance": balance}
+        )
+
+        # Each of these accounts stems from the MNEMONIC
+        expected_accounts = [
+            "0x1e59ce931b4cfea3fe4b875411e280e173cb7a9c",
+            "0xc89d42189f0450c2b2c3c61f58ec5d628176a1e7",
+            "0x318b469bba396aec2c60342f9441be36a1945174"
+        ]
+
+        # Test integration with EthereumTester
+        tester = EthereumTester(backend=pyevm_backend)
+
+        actual_accounts = tester.get_accounts()
+        assert len(actual_accounts) == num_accounts
+
+        for i in range(0, num_accounts):
+            actual = actual_accounts[i]
+            expected = expected_accounts[i]
+            assert actual.lower() == expected.lower()
+            assert tester.get_balance(account=actual) == balance
 
     def test_generate_custom_genesis_parameters(self):
 


### PR DESCRIPTION
### What was wrong?

I need to be able to control which accounts get funded. The way I have done this with other providers is via mnemonic. I was hoping we can add mnemonic support here as well?  Or at least, a way to set the private keys? I am able to set genesis data for funding accounts, but I can't actually make eth-tester use those accounts.

### How was it fixed?

Added `mnemonic` parameter and handle it by using tooling from `eth-account` to generate accounts that way instead of using the default.

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![baby_turtle](https://user-images.githubusercontent.com/19540978/139470886-3091691e-8792-4ec7-9334-b4e5f7472c10.png)

