### PR TITLE
chore: create public versions of methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,7 @@
-v0.6.0-beta.1
+v0.6.0-beta.1 (Unreleased)
 -------------
 
-Unreleased
-
 - Features
-
   - London support (https://github.com/ethereum/eth-tester/pull/206)
     - Upgrade py-evm to v0.5.0-alpha.1 for London support
     - Default to London
@@ -13,6 +10,8 @@ Unreleased
     - Transaction receipt param support for `type` and `effective_gas_price`
     - Block param support for `base_fee_per_gas`
   - Support for custom mnemonic when initializing the Backend for EthTester
+  - New public, pass-through methods PyEVMBackend.generate_genesis_params and
+    PyEVMBackend.generate_genesis_state
 
 - Misc
 

--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ to `PyEVM.generate_genesis_params`.
 >>> from eth_tester import PyEVMBackend, EthereumTester
 
 >>> genesis_overrides = {'gas_limit': 4500000}
->>> custom_genesis_params = PyEVMBackend._generate_genesis_params(overrides=genesis_overrides)
+>>> custom_genesis_params = PyEVMBackend.generate_genesis_params(overrides=genesis_overrides)
 
 # Generates the following `dict`:
 
@@ -911,7 +911,7 @@ For Example, to create 3 test accounts, each with a balance of 100 ETH each:
 >>>  from eth_utils import to_wei
 
 >>> state_overrides = {'balance': to_wei(100, 'ether')}
->>> custom_genesis_state = PyEVMBackend._generate_genesis_state(overrides=state_overrides, num_accounts=3)
+>>> custom_genesis_state = PyEVMBackend.generate_genesis_state(overrides=state_overrides, num_accounts=3)
 
 # Then pass the generated `custom_genesis_state` `dict` to the backend's `__init__`
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -342,9 +342,17 @@ class PyEVMBackend(BaseChainBackend):
     # Genesis
     #
 
+    @classmethod
+    def generate_genesis_params(cls, overrides=None):
+        return cls._generate_genesis_params(overrides=overrides)
+
     @staticmethod
     def _generate_genesis_params(overrides=None):
         return get_default_genesis_params(overrides=overrides)
+
+    @classmethod
+    def generate_genesis_state(cls, overrides=None, num_accounts=None):
+        return cls._generate_genesis_state(overrides=overrides, num_accounts=num_accounts)
 
     @staticmethod
     def _generate_genesis_state(overrides=None, num_accounts=None, mnemonic=None):

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -83,7 +83,7 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
             )
 
         # Use staticmethod state overriding
-        genesis_state = PyEVMBackend._generate_genesis_state(
+        genesis_state = PyEVMBackend.generate_genesis_state(
             overrides=state_overrides, num_accounts=3
         )
         assert len(genesis_state) == 3
@@ -93,7 +93,7 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
 
         # Only existing default genesis state keys can be overridden
         with pytest.raises(ValueError):
-            _invalid_genesis_state = PyEVMBackend._generate_genesis_state(
+            _invalid_genesis_state = PyEVMBackend.generate_genesis_state(
                 overrides=invalid_overrides
             )
 
@@ -102,7 +102,7 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
         test_accounts = 3
 
         # Initialize PyEVM backend with custom genesis state
-        genesis_state = PyEVMBackend._generate_genesis_state(
+        genesis_state = PyEVMBackend.generate_genesis_state(
             overrides=state_overrides, num_accounts=test_accounts
         )
 
@@ -159,13 +159,13 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
         assert genesis_params["gas_limit"] == param_overrides["gas_limit"]
 
         # Use the the staticmethod to generate custom genesis parameters
-        genesis_params = PyEVMBackend._generate_genesis_params(param_overrides)
+        genesis_params = PyEVMBackend.generate_genesis_params(param_overrides)
         assert genesis_params["gas_limit"] == param_overrides["gas_limit"]
 
         # Only existing default genesis parameter keys can be overridden
         invalid_overrides = {"gato": "con botas"}
         with pytest.raises(ValueError):
-            _invalid_genesis_params = PyEVMBackend._generate_genesis_params(
+            _invalid_genesis_params = PyEVMBackend.generate_genesis_params(
                 overrides=invalid_overrides
             )
 
@@ -176,7 +176,7 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
         block_one_gas_limit = param_overrides['gas_limit']
 
         # Initialize PyEVM backend with custom genesis parameters
-        genesis_params = PyEVMBackend._generate_genesis_params(
+        genesis_params = PyEVMBackend.generate_genesis_params(
             overrides=param_overrides
         )
         pyevm_backend = PyEVMBackend(genesis_parameters=genesis_params)


### PR DESCRIPTION
### What was wrong?

The README recommends using protected methods. It is difficult to know if this method is considered public or an implementation detail. I would like to be able to call these methods and not worry that they may break at some point.

### How was it fixed?

I made "public" classmethods that passthrough to the original static methods. This way, users who may be calling the protected methods won't have their stuff break.

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture
![baby_bear](https://user-images.githubusercontent.com/19540978/139596744-110a18ed-a121-49d3-bbec-4cc981825c49.jpeg)


