### PR TITLE
Update README.md with correct CI build status path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ Unreleased
 - Features
     - Allow `nonce` parameter for inbound transactions to `eth_call` and `eth_estimateGas`
 
+- Misc
+    - Update README.md with the link to the Circle CI build status
+
 v0.6.0-beta.1
 -------------
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Ethereum Tester
 
 [![Join the chat at https://gitter.im/ethereum/eth-tester](https://badges.gitter.im/ethereum/eth-tester.svg)](https://gitter.im/ethereum/eth-tester)
-
-[![Build Status](https://travis-ci.org/ethereum/eth-tester.png)](https://travis-ci.org/ethereum/eth-tester)
+[![Build Status](https://circleci.com/gh/ethereum/eth-tester.svg?style=shield)](https://app.circleci.com/pipelines/github/ethereum/eth-tester)
 
 
 Tools for testing ethereum based applications.


### PR DESCRIPTION
### What was wrong?

- There was an older Travis CI link in the readme for the CI build status

### How was it fixed?

- Replaced the Travis CI link with the link to Circle CI

### To-Do:

- [X] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![IMG_1330](https://user-images.githubusercontent.com/3532824/140866807-ca5e91c2-243c-409c-a804-63d91e490125.JPG)
