### PR TITLE
Don't add base_fee to block serializer until London

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Unreleased
+----------
+
+- Bugfixes
+
+	- Only add `base_fee_per_gas` to block serializer after London
+
+
 v0.6.0-beta.2
 -------------
 

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import pytest
 from eth.vm.forks import (
+    BerlinVM,
     FrontierVM,
     LondonVM,
 )
@@ -53,6 +54,37 @@ def test_custom_virtual_machines():
     # We should to make sure the VM config translates all the way to the main
     #   tester, maybe with a custom VM that hard-codes some block value? that can
     #   be found with tester.get_block_by_number()?
+    EthereumTester(backend=backend)
+
+
+def test_berlin_configuration():
+    if not is_pyevm_available():
+        pytest.skip("PyEVM is not available")
+
+    mnemonic = "test test test test test test test test test test test junk"
+    vm_configuration = ((0, BerlinVM),)
+    backend = PyEVMBackend.from_mnemonic(
+                mnemonic, vm_configuration=vm_configuration
+            )
+
+    # Berlin blocks shouldn't have base_fee_per_gas,
+    # since London was the fork that introduced base_fee_per_gas
+    with pytest.raises(KeyError):
+        backend.get_block_by_number(0)['base_fee_per_gas']
+
+    EthereumTester(backend=backend)
+
+
+def test_london_configuration():
+    if not is_pyevm_available():
+        pytest.skip("PyEVM is not available")
+
+    backend = PyEVMBackend(vm_configuration=(
+        (0, LondonVM),
+    ))
+
+    assert backend.get_block_by_number(0)['base_fee_per_gas'] == 1000000000
+
     EthereumTester(backend=backend)
 
 


### PR DESCRIPTION
### What was wrong?

Closes issue #216 - Base fee per gas was being added for all blocks, even those prior to London, which was causing an AttributeError.


### How was it fixed?
If the block is London or above, add `base_fee_per_gas` to the block attributes. Otherwise, leave it off. 



### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![Cute animal picture](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/chipmunk-nature-photos-1537973822.jpg)
