### PR TITLE
Support for pre-London blocks missing a base fee during validation

### DIFF
--- a/newsfragments/227.bugfix.rst
+++ b/newsfragments/227.bugfix.rst
@@ -1,0 +1,1 @@
+Support pre-London blocks with missing base fee by setting the ``base_fee_per_gas`` value to ``None`` during block validation and popping it back out during block normalization

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -72,7 +72,14 @@ def test_berlin_configuration():
     with pytest.raises(KeyError):
         backend.get_block_by_number(0)['base_fee_per_gas']
 
-    EthereumTester(backend=backend)
+    tester = EthereumTester(backend=backend)
+
+    # Test that outbound block validation doesn't break by getting a block.
+    berlin_block = tester.get_block_by_number(0)
+
+    # Test that outbound block normalization removes `base_fee_per_gas`.
+    with pytest.raises(KeyError):
+        berlin_block['base_fee_per_gas']
 
 
 def test_london_configuration():


### PR DESCRIPTION
### What was wrong?

- We had removed ``base_fee_per_gas`` serialization from pre-London blocks but we were still validating all blocks equally. This would break pre-London blocks on a simple `get_block()` call.

### How was it fixed?

- Set ``base_fee_per_gas`` value to ``None`` during validation if the param is missing (pre-London blocks). Pop this value back out during block normalization. This returns a block without a ``base_fee_per_gas`` for pre-London blocks which seems to be the default behavior in other clients as well.

### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20210611_143529](https://user-images.githubusercontent.com/3532824/142517731-68679737-1a79-48c8-aa12-668d8a1f981a.jpg)