### PR TITLE
Update dependency requirements for py-evm, eth-abi, eth-account, eth-keys, eth-utils, pyrlp

### DIFF
--- a/newsfragments/230.misc.rst
+++ b/newsfragments/230.misc.rst
@@ -1,0 +1,1 @@
+Updated dependency requirements for py-evm, eth-abi, eth-account, eth-keys, eth-utils, and pyrlp

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.5.0a1",
+        "py-evm==0.5.0a2",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],
@@ -57,11 +57,11 @@ setup(
     url='https://github.com/ethereum/eth-tester',
     include_package_data=True,
     install_requires=[
-        "eth-abi>=2.0.0b4,<3.0.0",
-        "eth-account>=0.5.6,<0.6.0",
-        "eth-keys>=0.2.1,<0.4.0",
-        "eth-utils>=1.4.1,<2.0.0",
-        "rlp>=1.1.0,<3",
+        "eth-abi>=3.0.0,<4.0.0",
+        "eth-account>=0.6.0,<0.7.0",
+        "eth-keys>=0.4.0,<0.5.0",
+        "eth-utils>=2.0.0,<3.0.0",
+        "rlp>=3.0.0,<4",
         "semantic_version>=2.6.0,<3.0.0",
     ],
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?
Updated dependency requirements for py-evm, eth-abi, eth-account, eth-keys, eth-utils, and pyrlp.




### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/6540608/150425351-1300452e-6520-41db-b680-e8af3131cf7e.png)
