### PR TITLE
Drop Python 3.6 support, add Python 3.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
   py37-pyevm:
     <<: *common
     docker:
@@ -88,6 +94,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-pyevm
+  py310-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-pyevm
 
 workflows:
   version: 2
@@ -97,7 +109,9 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core
       - py37-pyevm
       - py38-pyevm
       - py39-pyevm
+      - py310-pyevm
       - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.9
         environment:
           TOXENV: lint
   docs:
@@ -52,12 +52,6 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: docs
-  py36-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-core
   py37-core:
     <<: *common
     docker:
@@ -76,12 +70,6 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
-  py36-pyevm:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-pyevm
   py37-pyevm:
     <<: *common
     docker:
@@ -106,11 +94,9 @@ workflows:
   test:
     jobs:
       - lint
-      - py36-core
       - py37-core
       - py38-core
       - py39-core
-      - py36-pyevm
       - py37-pyevm
       - py38-pyevm
       - py39-pyevm

--- a/newsfragments/231.feature.rst
+++ b/newsfragments/231.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.10

--- a/newsfragments/231.removal.rst
+++ b/newsfragments/231.removal.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.6

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ extras_require = {
         'flake8>=3.5.0,<4.0.0',
     ],
     'test': [
-        'pytest>=4.4.0,<5.0.0',
-        'pytest-xdist>=1.22.2,<2',
+        'pytest>=6.2.5,<7',
+        'pytest-xdist>=2.0.0,<3',
         'eth-hash[pycryptodome]>=0.1.4,<1.0.0',
     ],
     'dev': [
@@ -80,5 +80,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,38,39}-{core,pyevm}
+    py{37,38,39}-{core,pyevm}
     lint
     docs
 
@@ -19,7 +19,6 @@ commands=
 deps =
     coincurve>=6.0.0
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38,39}-{core,pyevm}
+    py{37,38,39,310}-{core,pyevm}
     lint
     docs
 
@@ -22,6 +22,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     docs: python3.9
 extras =
     test


### PR DESCRIPTION
### What was wrong?
Adds Python 3.10 support, drops python 3.6 support. This is needed for our other dependency upgrades.



### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://images.fineartamerica.com/images-medium-large-5/two-cute-red-toy-poodle-puppies-mark-taylor.jpg)
