### PR TITLE
Downgrade upstream dependency requirements

### DIFF
--- a/newsfragments/232.bugfix.rst
+++ b/newsfragments/232.bugfix.rst
@@ -1,0 +1,1 @@
+Revert upstream dependency requirements so they can be pulled into the current web3.py (v5)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.5.0a2",
+        "py-evm==0.5.0a3",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],
@@ -57,11 +57,11 @@ setup(
     url='https://github.com/ethereum/eth-tester',
     include_package_data=True,
     install_requires=[
-        "eth-abi>=3.0.0,<4.0.0",
-        "eth-account>=0.6.0,<0.7.0",
-        "eth-keys>=0.4.0,<0.5.0",
-        "eth-utils>=2.0.0,<3.0.0",
-        "rlp>=3.0.0,<4",
+        "eth-abi>=2.0.0b4,<3.0.0",
+        "eth-account>=0.5.6,<0.6.0",
+        "eth-keys>=0.3.4,<0.4.0",
+        "eth-utils>=1.4.1,<2.0.0",
+        "rlp>=1.1.0,<3",
         "semantic_version>=2.6.0,<3.0.0",
     ],
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

See https://github.com/ethereum/py-evm/pull/2050. I did a premature upgrading of dependencies with breaking changes. Once we're ready to cut a new web3.py v6 branch, we can pull in the breaking upstream dependencies.


### How was it fixed?

Pulled in the needed non-breaking changes, and left the breaking changes until we're ready to cut a new web3.py v6. 


### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://image.shutterstock.com/image-photo/smiling-baby-piglet-clipping-path-260nw-301031825.jpg)
