### PR TITLE
Breaking Dependency Changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ test-all:
 
 validate-docs:
 	python newsfragments/validate_files.py
-	towncrier --draft
+	towncrier build --draft
 
-notes:
+notes: validate-docs
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
-	towncrier --yes --version $(UPCOMING_VERSION)
+	towncrier build --yes --version $(UPCOMING_VERSION)
 	git commit -m "Compile release notes"
 
 release: clean

--- a/newsfragments/230.misc.rst
+++ b/newsfragments/230.misc.rst
@@ -1,0 +1,1 @@
+Updated dependency requirements for py-evm, eth-abi, eth-account, eth-keys, eth-utils, and pyrlp

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=3.0.0,<4.0.0",
-        "eth-account>=0.6.0,<0.7.0",
+        "eth-account>=0.6.0,<0.8.0",
         "eth-keys>=0.4.0,<0.5.0",
         "eth-utils>=2.0.0,<3.0.0",
         "rlp>=3.0.0,<4",

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ extras_require = {
     'py-evm': [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.5.0a3",
+        "py-evm==0.6.0a1",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],
     'docs': [
-        'towncrier==18.5.0',
+        'towncrier>=21,<22',
     ]
 }
 
@@ -57,11 +57,11 @@ setup(
     url='https://github.com/ethereum/eth-tester',
     include_package_data=True,
     install_requires=[
-        "eth-abi>=2.0.0b4,<3.0.0",
-        "eth-account>=0.5.6,<0.6.0",
-        "eth-keys>=0.3.4,<0.4.0",
-        "eth-utils>=1.4.1,<2.0.0",
-        "rlp>=1.1.0,<3",
+        "eth-abi>=3.0.0,<4.0.0",
+        "eth-account>=0.6.0,<0.7.0",
+        "eth-keys>=0.4.0,<0.5.0",
+        "eth-utils>=2.0.0,<3.0.0",
+        "rlp>=3.0.0,<4",
         "semantic_version>=2.6.0,<3.0.0",
     ],
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

Need to upgrade the dependencies and issue a sem-versioned breaking release



### How was it fixed?

Cherry-picked the correct commit, upgraded py-evm since that has the right sem version now, and upgraded towncrier. I could totes pull out the towncrier version into another PR if anyone feels strongly. I also made sure all these dependencies install in web3 v6.


### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](http://blog.workman.com/wp-content/uploads/2015/02/Baby-Capybara-1.jpg)
