### PR TITLE
update all references to deprecated eth_abi.encode_abi to eth_abi.encode

### DIFF
--- a/eth_tester/tools/gas_burner_contract.py
+++ b/eth_tester/tools/gas_burner_contract.py
@@ -5,7 +5,7 @@ from eth_utils import (
     function_abi_to_4byte_selector,
 )
 
-from eth_abi import encode_abi
+from eth_abi import encode
 
 # The following contract burns gas relative to the current block number. The
 # higher the block number, the more gas is burned. It is used to test
@@ -67,6 +67,6 @@ def _make_call_gas_burner_transaction(
         "from": eth_tester.get_accounts()[0],
         "to": contract_address,
         "gas": 500000,
-        "data": encode_hex(fn_selector + encode_abi(arg_types, fn_args)),
+        "data": encode_hex(fn_selector + encode(arg_types, fn_args)),
     }
     return transaction

--- a/eth_tester/utils/emitter_contract.py
+++ b/eth_tester/utils/emitter_contract.py
@@ -254,7 +254,7 @@ def _deploy_emitter(eth_tester):
 
 
 def _call_emitter(eth_tester, contract_address, fn_name, fn_args):
-    from eth_abi import encode_abi
+    from eth_abi import encode
 
     fn_abi = EMITTER_ABI[fn_name]
     arg_types = [arg_abi["type"] for arg_abi in fn_abi["inputs"]]
@@ -264,7 +264,7 @@ def _call_emitter(eth_tester, contract_address, fn_name, fn_args):
             "from": eth_tester.get_accounts()[0],
             "to": contract_address,
             "gas": 500000,
-            "data": encode_hex(fn_selector + encode_abi(arg_types, fn_args)),
+            "data": encode_hex(fn_selector + encode(arg_types, fn_args)),
         }
     )
     return emit_a_hash

--- a/eth_tester/utils/math_contract.py
+++ b/eth_tester/utils/math_contract.py
@@ -116,7 +116,7 @@ def _deploy_math(eth_tester):
 
 
 def _make_call_math_transaction(eth_tester, contract_address, fn_name, fn_args=None):
-    from eth_abi import encode_abi
+    from eth_abi import encode
 
     if fn_args is None:
         fn_args = tuple()
@@ -128,7 +128,7 @@ def _make_call_math_transaction(eth_tester, contract_address, fn_name, fn_args=N
         "from": eth_tester.get_accounts()[0],
         "to": contract_address,
         "gas": 500000,
-        "data": encode_hex(fn_selector + encode_abi(arg_types, fn_args)),
+        "data": encode_hex(fn_selector + encode(arg_types, fn_args)),
     }
     return transaction
 

--- a/eth_tester/utils/throws_contract.py
+++ b/eth_tester/utils/throws_contract.py
@@ -121,7 +121,7 @@ def _deploy_throws(eth_tester, contract_name):
 def _make_call_throws_transaction(
     eth_tester, contract_address, contract_name, fn_name, fn_args=None
 ):
-    from eth_abi import encode_abi
+    from eth_abi import encode
 
     if fn_args is None:
         fn_args = tuple()
@@ -133,7 +133,7 @@ def _make_call_throws_transaction(
         "from": eth_tester.get_accounts()[0],
         "to": contract_address,
         "gas": 500000,
-        "data": encode_hex(fn_selector + encode_abi(arg_types, fn_args)),
+        "data": encode_hex(fn_selector + encode(arg_types, fn_args)),
     }
     return transaction
 

--- a/newsfragments/242.feature.rst
+++ b/newsfragments/242.feature.rst
@@ -1,0 +1,1 @@
+update all references to deprecated `eth_abi.encode_abi` to `eth_abi.encode`


### PR DESCRIPTION
### What was wrong?

We were still calling the deprecated method eth_abi.encode_abi.

### How was it fixed?

Changed all calls to the new eth_abi.encode.

### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/187744712-d30b44c8-016c-4b16-a22e-475b1c6f9360.png)

