### PR TITLE
upgrade eth-account dependency requirement

### DIFF
--- a/newsfragments/250.misc.rst
+++ b/newsfragments/250.misc.rst
@@ -1,0 +1,1 @@
+Remove upper pin on eth-account dependency

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=3.0.1",
-        "eth-account>=0.6.0,<0.8.0",
+        "eth-account>=0.6.0",
         "eth-keys>=0.4.0,<0.5.0",
         "eth-utils>=2.0.0,<3.0.0",
         "rlp>=3.0.0,<4",

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ exclude= tests/*
 
 [testenv]
 usedevelop=True
-whitelist_externals=
+allowlist_externals=
     /usr/bin/make
 commands=
     core: pytest {posargs:tests/core}


### PR DESCRIPTION
### What was wrong?
In order to get dependencies to resolve in web3.py for Python 3.11 support, we had to upgrade the eth-abi dependency via eth-account.


### How was it fixed?
Removed the upper pin on eth-account to support the latest release. 


### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://media.istockphoto.com/id/482435302/photo/cute-kitten.jpg?s=612x612&w=0&k=20&c=YTQBqynRYF7BINHgumv9YuETP0dVJ2KAUZy19MBiKOc=)
