### PR TITLE
Bump py-evm

### DIFF
--- a/newsfragments/251.misc.rst
+++ b/newsfragments/251.misc.rst
@@ -1,0 +1,1 @@
+Bump py-evm dependency

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
     "py-evm": [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.6.1a1",
+        "py-evm==0.6.1a2",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?
web3.py isn't able to resolve dependencies for Python 3.11 support. Had to remove the upper pin of `eth-bloom` in `py-evm` and then pull that in here. 


### How was it fixed?
Bumped py-evm to a version that might resolve for web3.py



### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://cdn.britannica.com/72/158272-004-7FA9DFA9/baby-platypuses-Healesville-Sanctuary-Australia-Victoria.jpg)
