### PR TITLE
Shanghai support, pending `py-evm` release

### DIFF
--- a/eth_tester/backends/mock/factory.py
+++ b/eth_tester/backends/mock/factory.py
@@ -276,6 +276,8 @@ def make_genesis_block(overrides=None):
         "uncles": [],
         # base fee at London fork block 12965000 on mainnet
         "base_fee_per_gas": 1000000000,
+        "withdrawals": [],
+        "withdrawals_root": BLANK_ROOT_HASH,
     }
     if overrides is not None:
         genesis_block = merge_genesis_overrides(
@@ -397,6 +399,16 @@ def make_block_from_parent(parent_block, overrides=None):
         yield "base_fee_per_gas", overrides["base_fee_per_gas"]
     else:
         yield "base_fee_per_gas", _calculate_expected_base_fee_per_gas(parent_block)
+
+    if "withdrawals" in overrides:
+        yield "withdrawals", overrides["withdrawals"]
+    else:
+        yield "withdrawals", []
+
+    if "withdrawals_root" in overrides:
+        yield "withdrawals_root", overrides["withdrawals_root"]
+    else:
+        yield "withdrawals_root", BLANK_ROOT_HASH
 
 
 def _calculate_expected_base_fee_per_gas(parent_block) -> int:

--- a/eth_tester/backends/mock/serializers.py
+++ b/eth_tester/backends/mock/serializers.py
@@ -20,7 +20,13 @@ def serialize_block(block, transaction_serializer, is_pending):
         )
         for transaction_index, transaction in enumerate(block["transactions"])
     )
-    return assoc(block, "transactions", serialized_transactions)
+    block_with_transactions = assoc(block, "transactions", serialized_transactions)
+    block_with_withdrawals = assoc(
+        block_with_transactions,
+        "withdrawals",
+        block["withdrawals"],
+    )
+    return block_with_withdrawals
 
 
 def serialize_transaction_as_hash(transaction, block, transaction_index, is_pending):

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -46,7 +46,7 @@ from .serializers import (
     serialize_transaction_receipt,
 )
 from .utils import is_supported_pyevm_version_available
-from ...validation.inbound import validate_withdrawal_dict
+from ...validation.inbound import validate_inbound_withdrawals
 
 
 if is_supported_pyevm_version_available():
@@ -671,14 +671,13 @@ class PyEVMBackend(BaseChainBackend):
 
     def apply_withdrawals(
         self,
-        withdrawal_dicts: List[Dict[str, Union[int, str]]],
+        withdrawals_list: List[Dict[str, Union[int, str]]],
     ) -> None:
         """
         Apply a withdrawal to the state and mine the block that includes the
         withdrawal information.
         """
-        for withdrawal_dict in withdrawal_dicts:
-            validate_withdrawal_dict(withdrawal_dict)
+        validate_inbound_withdrawals(withdrawals_list)
 
         vm = _get_vm_for_block_number(self.chain, "latest")
         if not isinstance(vm, ShanghaiVM):
@@ -695,7 +694,7 @@ class PyEVMBackend(BaseChainBackend):
                 ),
                 amount=withdrawal_dict["amount"],
             )
-            for withdrawal_dict in withdrawal_dicts
+            for withdrawal_dict in withdrawals_list
         ]
         self.chain.mine_all(transactions=[], withdrawals=withdrawals)
 

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -674,8 +674,7 @@ class PyEVMBackend(BaseChainBackend):
         withdrawals_list: List[Dict[str, Union[int, str]]],
     ) -> None:
         """
-        Apply a withdrawal to the state and mine the block that includes the
-        withdrawal information.
+        Apply withdrawals to the state and mine the block that includes the withdrawals.
         """
         validate_inbound_withdrawals(withdrawals_list)
 

--- a/eth_tester/backends/pyevm/serializers.py
+++ b/eth_tester/backends/pyevm/serializers.py
@@ -12,13 +12,9 @@ from .utils import is_supported_pyevm_version_available
 if is_supported_pyevm_version_available():
     from eth.rlp.transactions import BaseTransaction
     from eth.vm.forks.berlin.transactions import TypedTransaction
-    from eth.vm.forks.london.blocks import LondonBlock
-    from eth.vm.forks.shanghai import ShanghaiBlock
 else:
     BaseTransaction = None
     TypedTransaction = None
-    LondonBlock = None
-    ShanghaiBlock = None
 
 from eth_tester.exceptions import ValidationError
 from eth_tester.utils.address import (
@@ -70,13 +66,11 @@ def serialize_block(block, full_transaction, is_pending):
         "uncles": [uncle.hash for uncle in block.uncles],
     }
 
-    # blocks after London should inherit from LondonBlock,
-    # so this should also work for future hard forks
-    if isinstance(block, LondonBlock):
+    if hasattr(block.header, "base_fee_per_gas"):
         base_fee = block.header.base_fee_per_gas
         block_info.update({"base_fee_per_gas": base_fee})
 
-    if isinstance(block, ShanghaiBlock):
+    if hasattr(block.header, "withdrawals_root") and hasattr(block, "withdrawals"):
         block_info.update({"withdrawals": serialize_block_withdrawals(block)})
         block_info.update({"withdrawals_root": block.header.withdrawals_root})
 

--- a/eth_tester/constants.py
+++ b/eth_tester/constants.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 UINT256_MIN = 0
 UINT256_MAX = 2**256 - 1
+UINT64_MAX = 2**64 - 1
 UINT8_MAX = 2**8 - 1
 UINT2048_MAX = 2**2048 - 1
 

--- a/eth_tester/normalization/outbound.py
+++ b/eth_tester/normalization/outbound.py
@@ -100,7 +100,6 @@ def _remove_fork_specific_fields_if_none(block):
     """
     for key, value in list(block.items()):
         if value is None:
-            print(key, value)
             block = dissoc(block, key)
     return block
 

--- a/eth_tester/normalization/outbound.py
+++ b/eth_tester/normalization/outbound.py
@@ -75,6 +75,15 @@ TRANSACTION_NORMALIZERS = {
 normalize_transaction = partial(normalize_dict, normalizers=TRANSACTION_NORMALIZERS)
 
 
+WITHDRAWAL_NORMALIZERS = {
+    "index": identity,
+    "validator_index": identity,
+    "address": to_checksum_address,
+    "amount": identity,
+}
+normalize_withdrawal = partial(normalize_dict, normalizers=WITHDRAWAL_NORMALIZERS)
+
+
 def is_transaction_hash_list(value):
     return all(is_bytes(item) for item in value)
 
@@ -125,9 +134,12 @@ BLOCK_NORMALIZERS = {
         ),
     ),
     "uncles": partial(normalize_array, normalizer=encode_hex),
+    "withdrawals": partial(normalize_array, normalizer=normalize_withdrawal),
+    "withdrawals_root": encode_hex,
 }
 normalize_block = compose(
-    _remove_base_fee_if_none, partial(normalize_dict, normalizers=BLOCK_NORMALIZERS)
+    _remove_base_fee_if_none,
+    partial(normalize_dict, normalizers=BLOCK_NORMALIZERS),
 )
 
 

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -99,7 +99,6 @@ BLOCK_KEYS = {
     "timestamp",
     "transactions",
     "uncles",
-    "base_fee_per_gas",
 }
 
 

--- a/eth_tester/validation/common.py
+++ b/eth_tester/validation/common.py
@@ -21,6 +21,7 @@ from eth_utils.toolz import (
 
 from eth_tester.constants import (
     UINT256_MAX,
+    UINT64_MAX,
     UINT8_MAX,
 )
 from eth_tester.exceptions import (
@@ -49,6 +50,7 @@ def validate_uint(max_val, value):
 
 
 validate_uint256 = validate_uint(UINT256_MAX)
+validate_uint64 = validate_uint(UINT64_MAX)
 validate_uint8 = validate_uint(UINT8_MAX)
 
 

--- a/eth_tester/validation/common.py
+++ b/eth_tester/validation/common.py
@@ -3,8 +3,15 @@ from __future__ import unicode_literals
 import math
 
 import functools
+from typing import (
+    Union,
+)
 
+from eth_typing import (
+    HexStr,
+)
 from eth_utils import (
+    is_address,
     is_bytes,
     is_hexstr,
     is_text,
@@ -205,3 +212,8 @@ def if_not_create_address(validator_fn):
             validator_fn(value)
 
     return inner
+
+
+def validate_address(value: Union[str, HexStr, bytes]):
+    if not is_address(value):
+        raise ValidationError(f"Value must be a valid address. Got: {value}")

--- a/eth_tester/validation/inbound.py
+++ b/eth_tester/validation/inbound.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 
 import binascii
+from typing import Dict, Union
 
+from eth_typing import HexStr
 from eth_utils import (
+    is_address,
     is_boolean,
     is_checksum_address,
     is_checksum_formatted_address,
@@ -338,4 +341,29 @@ def validate_raw_transaction(raw_transaction):
         raise ValidationError(
             "Raw Transaction must be a hexadecimal encoded string.  Got: "
             "{}".format(raw_transaction)
+        )
+
+
+def validate_withdrawal_dict(
+    withdrawal_dict: Dict[str, Union[int, str, HexStr, bytes]],
+):
+    all_keys_in_dict = all(
+        _key in withdrawal_dict
+        for _key in ("index", "validator_index", "address", "amount")
+    )
+    all_ints_valid = all(
+        is_integer(_value)
+        for _value in (
+            withdrawal_dict["index"],
+            withdrawal_dict["validator_index"],
+            withdrawal_dict["amount"],
+        )
+    )
+    address_valid = is_address(withdrawal_dict["address"])
+
+    if not all((all_keys_in_dict, all_ints_valid, address_valid)):
+        raise ValidationError(
+            "Withdrawal needs to be formatted as a dict with keys "
+            "'index', 'validator_index', and 'amount' mapping to integer values "
+            "and 'address' with valid address value as a hex string or bytes."
         )

--- a/eth_tester/validation/outbound.py
+++ b/eth_tester/validation/outbound.py
@@ -33,6 +33,7 @@ from .common import (
     validate_dict,
     validate_transaction_type,
     validate_uint256,
+    validate_uint64,
 )
 
 
@@ -184,6 +185,15 @@ validate_transaction = partial(
 )
 
 
+WITHDRAWAL_VALIDATORS = {
+    "index": validate_uint64,
+    "validator_index": validate_uint64,
+    "address": validate_canonical_address,
+    "amount": validate_uint64,
+}
+validate_withdrawal = partial(validate_dict, key_validators=WITHDRAWAL_VALIDATORS)
+
+
 def validate_status(value):
     validate_positive_integer(value)
     if value > 1:
@@ -239,6 +249,8 @@ BLOCK_VALIDATORS = {
         ),
     ),
     "uncles": partial(validate_array, validator=validate_32_byte_string),
+    "withdrawals": partial(validate_array, validator=validate_withdrawal),
+    "withdrawals_root": validate_32_byte_string,
 }
 
 

--- a/newsfragments/257.feature.rst
+++ b/newsfragments/257.feature.rst
@@ -1,0 +1,1 @@
+Add support for ``Shanghai`` network upgrade and add method on ``PyEVMBackend`` to be able to initiate withdrawals.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
     "py-evm": [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.7.0a1",
+        "py-evm==0.7.0a2",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
     "py-evm": [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.6.1a2",
+        "py-evm==0.7.0a1",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

- Needs Shanghai support, mostly in the form of supporting withdrawals.

Note: This PR revealed a bug in the link between eth-tester and py-evm. This PR will fail until [this fix](https://github.com/ethereum/py-evm/pull/2105) is merged and release.

### How was it fixed?

- Added `withdrawals` and `withdrawals_root` fields where appropriate
- Added a way to `apply_withdrawal()`, passing in a dict with appropriate values via a method on `PyEVMBackend` since withdrawals are not done via an API call on EL, but rather through configs on the CL client.
- Added some testing around outbound blocks with withdrawals.
- Added validation for "inbound" withdrawals dict object for the `apply_withdrawal()` method.

### To-Do:

- [x] Add proper tests for the `apply_withdrawal()` method and validation tests for the inbound withdrawal dict (this was only manually tested thus far)
- [x] Link up this branch locally and a new web3.py branch for peripheral changes related to Shanghai (e.g. `withdrawals_root` -> `withdrawalsRoot` in the "RPC" response for eth_getBlockBy* calls)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture
```
 /\ /\
 ( oo)
  =======~~~
  /\    /\
```