### PR TITLE
Bump py-evm version requirement

### DIFF
--- a/newsfragments/268.internal.rst
+++ b/newsfragments/268.internal.rst
@@ -1,0 +1,1 @@
+Bump ``py-evm`` dependency to ``v0.7.0-a.4``

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
     "py-evm": [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.7.0a2",
+        "py-evm==0.7.0a4",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

py-evm had some changes that haven't been pulled into eth-tester just yet. 

### How was it fixed?

Bumped the dependency. 

### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://www.dailypaws.com/thmb/d3vNqnLf6Vqjz8oz5XObGCQxms4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/tiny-white-kitten-873941684-2000-0bac130389984aba9751de5e5e50d25f.jpg)
