### PR TITLE
fee history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,14 @@ value from the evm.
 Executes the provided `transaction` object, measuring and returning the gas
 consumption.
 
+<a id="api-fee_history"></a>
+
+#### `EthereumTester.get_fee_history(block_count=1, newest_block='latest', reward_percentiles=[])`
+
+Return the historical gas information for the number of blocks specified as the `block_count` starting from `newest_block`.
+Note that specifying `reward_percentiles` has no effect on the response and so `reward` will always return an  empty list.
+
+
 
 ### Logs and Filters
 

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ consumption.
 #### `EthereumTester.get_fee_history(block_count=1, newest_block='latest', reward_percentiles=[])`
 
 Return the historical gas information for the number of blocks specified as the `block_count` starting from `newest_block`.
-Note that specifying `reward_percentiles` has no effect on the response and so `reward` will always return an  empty list.
+Note that specifying `reward_percentiles` has no effect on the response and so `reward` will always return an empty list.
 
 
 

--- a/eth_tester/backends/mock/main.py
+++ b/eth_tester/backends/mock/main.py
@@ -322,3 +322,13 @@ class MockBackend(BaseChainBackend):
 
     def call(self, transaction, block_number="latest"):
         raise NotImplementedError("Must be implemented by subclasses")
+
+    def get_fee_history(
+        self, block_count=1, newest_block="latest", reward_percentiles=[]
+    ):
+        return {
+            "oldest_block": 1,
+            "base_fee_per_gas": [],
+            "gas_used_ratio": [],
+            "reward": [],
+        }

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -524,6 +524,37 @@ class PyEVMBackend(BaseChainBackend):
             is_pending,
         )
 
+    def get_fee_history(
+        self, block_count=1, newest_block="latest", reward_percentiles: List[int] = []
+    ):
+        if isinstance(block_count, int) and not 1 <= block_count <= 1024:
+            raise ValidationError("block_count must be between 1 and 1024")
+
+        if newest_block == "pending":
+            raise NotImplementedError(
+                '"pending" block identifier is unsupported in eth-tester'
+            )
+
+        block = self.get_block_by_number(newest_block)
+        block_header = self.chain.get_canonical_block_header_by_number(block["number"])
+
+        ancestors = self.chain.get_ancestors(block_count, header=block_header)
+
+        base_fee_per_gas = []
+        gas_used_ratio = []
+        reward = []  # always return empty reward array for now
+
+        for ancestor in ancestors:
+            base_fee_per_gas.append(ancestor.header.base_fee_per_gas)
+            gas_used_ratio.append(ancestor.header.gas_used / ancestor.header.gas_limit)
+
+        return {
+            "oldest_block": 1,
+            "base_fee_per_gas": base_fee_per_gas,
+            "gas_used_ratio": gas_used_ratio,
+            "reward": reward,
+        }
+
     #
     # Account state
     #

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -531,9 +531,7 @@ class PyEVMBackend(BaseChainBackend):
             raise ValidationError("block_count must be between 1 and 1024")
 
         if newest_block == "pending":
-            raise NotImplementedError(
-                '"pending" block identifier is unsupported in eth-tester'
-            )
+            newest_block = "latest"
 
         block = self.get_block_by_number(newest_block)
         block_header = self.chain.get_canonical_block_header_by_number(block["number"])

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -5,6 +5,7 @@ import itertools
 import operator
 import time
 import functools
+from typing import List
 
 from eth_typing import (
     HexAddress,
@@ -362,6 +363,14 @@ class EthereumTester:
         self.validator.validate_outbound_receipt(raw_receipt)
         receipt = self.normalizer.normalize_outbound_receipt(raw_receipt)
         return receipt
+
+    def get_fee_history(
+        self, block_count=1, newest_block="latest", reward_percentiles: List[int] = []
+    ):
+        fee_history = self.backend.get_fee_history(
+            block_count, newest_block, reward_percentiles
+        )
+        return fee_history
 
     #
     # Mining

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -284,6 +284,16 @@ class BaseTestBackendDirect:
                     "reward": [],
                 },
             ],
+            [
+                1,
+                "pending",
+                [],
+                {
+                    "base_fee_per_gas": [300657803],
+                    "gas_used_ratio": [0.0],
+                    "reward": [],
+                },
+            ],
         ],
     )
     def test_get_fee_history(

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -328,13 +328,6 @@ class BaseTestBackendDirect:
                 ValidationError,
                 "block_count must be between 1 and 1024",
             ],
-            [
-                1,
-                "pending",
-                None,
-                NotImplementedError,
-                '"pending" block identifier is unsupported in eth-tester',
-            ],
         ],
     )
     def test_get_fee_history_fails(

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -239,6 +239,105 @@ class BaseTestBackendDirect:
         assert nonce <= UINT256_MAX
 
     #
+    # Fee History
+    #
+    @pytest.mark.parametrize(
+        "block_count,newest_block,reward_percentiles,expected",
+        [
+            [
+                3,
+                "latest",
+                [],
+                {
+                    "base_fee_per_gas": [300657803, 343608917, 392695905],
+                    "gas_used_ratio": [0.0, 0.0, 0.0],
+                    "reward": [],
+                },
+            ],
+            [
+                1,
+                "safe",
+                [],
+                {
+                    "base_fee_per_gas": [300657803],
+                    "gas_used_ratio": [0.0],
+                    "reward": [],
+                },
+            ],
+            [
+                1,
+                "finalized",
+                [],
+                {
+                    "base_fee_per_gas": [300657803],
+                    "gas_used_ratio": [0.0],
+                    "reward": [],
+                },
+            ],
+            [
+                1,
+                "earliest",
+                [],
+                {
+                    "base_fee_per_gas": [],
+                    "gas_used_ratio": [],
+                    "reward": [],
+                },
+            ],
+        ],
+    )
+    def test_get_fee_history(
+        self, eth_tester, block_count, newest_block, reward_percentiles, expected
+    ):
+        self.skip_if_no_evm_execution()
+
+        eth_tester.mine_blocks(10)
+        fee_history = eth_tester.get_fee_history(
+            block_count, newest_block, reward_percentiles
+        )
+
+        assert fee_history["oldest_block"] == 1
+        assert fee_history["base_fee_per_gas"] == expected["base_fee_per_gas"]
+        assert fee_history["gas_used_ratio"] == expected["gas_used_ratio"]
+        assert fee_history["reward"] == expected["reward"]
+
+    @pytest.mark.parametrize(
+        "block_count,newest_block,reward_percentiles,error,message",
+        [
+            [
+                1,
+                None,
+                None,
+                BlockNotFound,
+                "No block found for block number: None",
+            ],
+            [
+                0,
+                None,
+                None,
+                ValidationError,
+                "block_count must be between 1 and 1024",
+            ],
+            [
+                1,
+                "pending",
+                None,
+                NotImplementedError,
+                '"pending" block identifier is unsupported in eth-tester',
+            ],
+        ],
+    )
+    def test_get_fee_history_fails(
+        self, eth_tester, block_count, newest_block, reward_percentiles, error, message
+    ):
+        self.skip_if_no_evm_execution()
+
+        eth_tester.mine_blocks(10)
+
+        with pytest.raises(error, match=message):
+            eth_tester.get_fee_history(block_count, newest_block, reward_percentiles)
+
+    #
     # Mining
     #
     def test_mine_block_single(self, eth_tester):

--- a/newsfragments/258.feature.rst
+++ b/newsfragments/258.feature.rst
@@ -1,0 +1,1 @@
+Add support for ``eth_getFeeHistory`` for ``PyEVMBackend`` via ``get_fee_history()`` method.

--- a/newsfragments/258.feature.rst
+++ b/newsfragments/258.feature.rst
@@ -1,1 +1,1 @@
-Add support for ``eth_getFeeHistory`` for ``PyEVMBackend`` via ``get_fee_history()`` method.
+Add support for ``eth_feeHistory`` for ``PyEVMBackend`` via ``get_fee_history()`` method.


### PR DESCRIPTION
### What was wrong?
Closes #258


### How was it fixed?

Add RPC endpoint to backends for eth_feeHistory

### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://www.desertsun.com/gcdn/presto/2020/06/03/PVCS/df40170c-936a-403d-9a04-80c397d62846-49966918813_b441402987_o.jpg)
