### PR TITLE
Upgrade eth-account

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -12,7 +12,7 @@ from eth_abi import (
 from eth_abi.exceptions import (
     DecodingError,
 )
-from eth_account._utils.typed_transactions import (
+from eth_account.typed_transactions import (
     BlobTransaction,
 )
 from eth_account.hdaccount import (

--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -12,12 +12,12 @@ from eth_abi import (
 from eth_abi.exceptions import (
     DecodingError,
 )
-from eth_account.typed_transactions import (
-    BlobTransaction,
-)
 from eth_account.hdaccount import (
     HDPath,
     seed_from_mnemonic,
+)
+from eth_account.typed_transactions import (
+    BlobTransaction,
 )
 from eth_keys import (
     KeyAPI,

--- a/newsfragments/293.breaking.rst
+++ b/newsfragments/293.breaking.rst
@@ -1,0 +1,1 @@
+Bump eth-account dependency to account for breaking changes in eth-account

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=3.0.1",
-        "eth-account>=0.11.2",
+        "eth-account>=0.12.3",
         "eth-keys>=0.4.0",
         "eth-utils>=2.0.0",
         "rlp>=3.0.0",

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -472,7 +472,7 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
         ) + self.ENCODED_BLOB_TEXT
 
         signed = acct.sign_transaction(tx, blobs=[blob_data])
-        tx_hash = eth_tester.send_raw_transaction(to_hex(signed.rawTransaction))
+        tx_hash = eth_tester.send_raw_transaction(to_hex(signed.raw_transaction))
         assert eth_tester.get_transaction_by_hash(tx_hash)
 
     def test_send_raw_transaction_invalid_blob_transaction(self, eth_tester):


### PR DESCRIPTION
### What was wrong?
- eth-account moved `TypedTransactions` up a dir, from `eth_account._utils` to `eth_account`. 
- eth-account also changed `rawTransaction` -> `raw_transaction`.

### How was it fixed?

- Changed the `TypedTransactions` import path
- Changed `rawTransaction` -> `raw_transaction`
- Bumped eth-account to `>=0.12.3`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.tallahassee.com/gcdn/presto/2018/09/19/PTAL/2b1a924e-6d73-405a-bdc2-c8d99f729ddc-Bobcat-by-Kelly-Pacchioli.jpg)
