### PR TITLE
Normalize outbound keys to camelCase

### DIFF
--- a/eth_tester/normalization/common.py
+++ b/eth_tester/normalization/common.py
@@ -13,7 +13,7 @@ from eth_tester.utils.encoding import (
 )
 
 
-def to_lower_camel_case(value):
+def to_lower_camel_case(value: str) -> str:
     """
     Convert a string to lower camel case.
     """

--- a/eth_tester/normalization/common.py
+++ b/eth_tester/normalization/common.py
@@ -13,13 +13,37 @@ from eth_tester.utils.encoding import (
 )
 
 
-def to_lower_camel_case(key):
+def to_lower_camel_case(value):
     """
     Convert a string to lower camel case.
     """
     return "".join(
-        word.capitalize() if i else word for i, word in enumerate(key.split("_"))
+        word.capitalize() if i else word for i, word in enumerate(value.split("_"))
     )
+
+
+@curry
+@to_dict
+def normalize_dict_keys_recursive(value):
+    """
+    Normalize the keys of a dictionary using the provided normalizer.
+    """
+    for key, item in value.items():
+        if isinstance(item, dict):
+            # Recursively normalize nested dictionary keys
+            yield normalize_dict_keys_recursive(item)
+        elif isinstance(item, (list, tuple)):
+            # Recursively normalize nested list items
+            # and normalize the keys of dictionaries within the list
+            checked_items = []
+            for sub_item in item:
+                if not isinstance(sub_item, dict):
+                    checked_items.append(sub_item)
+                else:
+                    checked_items.append(normalize_dict_keys_recursive(sub_item))
+            yield to_lower_camel_case(key), tuple(checked_items)
+        else:
+            yield to_lower_camel_case(key), item
 
 
 @curry
@@ -27,7 +51,7 @@ def to_lower_camel_case(key):
 def normalize_dict(value, normalizers):
     for key, item in value.items():
         normalizer = normalizers[key]
-        yield to_lower_camel_case(key), normalizer(item)
+        yield key, normalizer(item)
 
 
 @curry

--- a/eth_tester/normalization/common.py
+++ b/eth_tester/normalization/common.py
@@ -1,3 +1,9 @@
+from typing import (
+    Any,
+    Dict,
+    Generator,
+)
+
 from eth_utils import (
     encode_hex,
     is_hex,
@@ -22,9 +28,10 @@ def to_lower_camel_case(value: str) -> str:
     )
 
 
-@curry
 @to_dict
-def normalize_dict_keys_recursive(value):
+def normalize_dict_keys_recursive(
+    value: Dict[str, Any],
+) -> Generator[Dict[str, Any], None, None]:
     """
     Normalize the keys of a dictionary using the provided normalizer.
     """

--- a/eth_tester/normalization/common.py
+++ b/eth_tester/normalization/common.py
@@ -13,12 +13,21 @@ from eth_tester.utils.encoding import (
 )
 
 
+def to_lower_camel_case(key):
+    """
+    Convert a string to lower camel case.
+    """
+    return "".join(
+        word.capitalize() if i else word for i, word in enumerate(key.split("_"))
+    )
+
+
 @curry
 @to_dict
 def normalize_dict(value, normalizers):
     for key, item in value.items():
         normalizer = normalizers[key]
-        yield key, normalizer(item)
+        yield to_lower_camel_case(key), normalizer(item)
 
 
 @curry

--- a/eth_tester/normalization/outbound.py
+++ b/eth_tester/normalization/outbound.py
@@ -27,7 +27,9 @@ from ..utils.encoding import (
 from .common import (
     normalize_array,
     normalize_dict,
+    normalize_dict_keys_recursive,
     normalize_if,
+    to_lower_camel_case,
 )
 
 normalize_account = to_checksum_address
@@ -85,7 +87,11 @@ TRANSACTION_NORMALIZERS = {
     "v": identity,
     "y_parity": identity,
 }
-normalize_transaction = partial(normalize_dict, normalizers=TRANSACTION_NORMALIZERS)
+
+normalize_transaction = compose(
+    normalize_dict_keys_recursive,
+    partial(normalize_dict, normalizers=TRANSACTION_NORMALIZERS),
+)
 
 
 WITHDRAWAL_NORMALIZERS = {

--- a/eth_tester/normalization/outbound.py
+++ b/eth_tester/normalization/outbound.py
@@ -29,7 +29,6 @@ from .common import (
     normalize_dict,
     normalize_dict_keys_recursive,
     normalize_if,
-    to_lower_camel_case,
 )
 
 normalize_account = to_checksum_address
@@ -163,6 +162,7 @@ BLOCK_NORMALIZERS = {
     "excess_blob_gas": identity,
 }
 normalize_block = compose(
+    normalize_dict_keys_recursive,
     partial(normalize_dict, normalizers=BLOCK_NORMALIZERS),
     _remove_fork_specific_fields_if_none,
 )
@@ -187,7 +187,10 @@ LOG_ENTRY_NORMALIZERS = {
     "data": encode_hex,
     "topics": partial(normalize_array, normalizer=encode_hex),
 }
-normalize_log_entry = partial(normalize_dict, normalizers=LOG_ENTRY_NORMALIZERS)
+normalize_log_entry = compose(
+    normalize_dict_keys_recursive,
+    partial(normalize_dict, normalizers=LOG_ENTRY_NORMALIZERS),
+)
 
 
 def _normalize_contract_address(receipt):
@@ -227,6 +230,7 @@ RECEIPT_NORMALIZERS = {
     "blob_gas_price": identity,
 }
 normalize_receipt = compose(
+    normalize_dict_keys_recursive,
     partial(normalize_dict, normalizers=RECEIPT_NORMALIZERS),
     _normalize_contract_address,
 )

--- a/eth_tester/tools/gas_burner_contract.py
+++ b/eth_tester/tools/gas_burner_contract.py
@@ -49,7 +49,7 @@ def _deploy_gas_burner(eth_tester):
         }
     )
     deploy_receipt = eth_tester.get_transaction_receipt(deploy_hash)
-    gas_burner_address = deploy_receipt["contract_address"]
+    gas_burner_address = deploy_receipt["contractAddress"]
     assert gas_burner_address
     gas_burner_code = eth_tester.get_code(gas_burner_address)
     assert len(gas_burner_code) > 2

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -1,5 +1,5 @@
 import pytest
-
+import rlp
 from eth_keys import (
     keys,
 )
@@ -17,7 +17,6 @@ from eth_utils.toolz import (
     dissoc,
     merge,
 )
-import rlp
 
 from eth_tester.constants import (
     BURN_ADDRESS,
@@ -78,21 +77,21 @@ CONTRACT_TRANSACTION_MISSING_TO = dissoc(CONTRACT_TRANSACTION_EMPTY_TO, "to")
 BLOCK_KEYS = {
     "number",
     "hash",
-    "parent_hash",
+    "parentHash",
     "nonce",
-    "sha3_uncles",
-    "logs_bloom",
-    "transactions_root",
-    "receipts_root",
-    "state_root",
+    "sha3Uncles",
+    "logsBloom",
+    "transactionsRoot",
+    "receiptsRoot",
+    "stateRoot",
     "coinbase",
     "difficulty",
-    "mix_hash",
-    "total_difficulty",
+    "mixHash",
+    "totalDifficulty",
     "size",
-    "extra_data",
-    "gas_limit",
-    "gas_used",
+    "extraData",
+    "gasLimit",
+    "gasUsed",
     "timestamp",
     "transactions",
     "uncles",
@@ -131,14 +130,14 @@ class BaseTestBackendDirect:
         assert actual_transaction["value"] == sent_transaction["value"]
 
         if sent_transaction.get("gas_price") is not None:
-            assert actual_transaction["gas_price"] == sent_transaction["gas_price"]
+            assert actual_transaction["gasPrice"] == sent_transaction["gas_price"]
         else:
             assert (
-                actual_transaction["max_fee_per_gas"]
+                actual_transaction["maxFeePerGas"]
                 == sent_transaction["max_fee_per_gas"]
             )
             assert (
-                actual_transaction["max_priority_fee_per_gas"]
+                actual_transaction["maxPriorityFeePerGas"]
                 == sent_transaction["max_priority_fee_per_gas"]
             )
 
@@ -360,9 +359,9 @@ class BaseTestBackendDirect:
 
     def test_gas_limit_constant(self, eth_tester):
         eth_tester.mine_blocks()
-        before_gas_limit = eth_tester.get_block_by_number("latest")["gas_limit"]
+        before_gas_limit = eth_tester.get_block_by_number("latest")["gasLimit"]
         eth_tester.mine_blocks()
-        after_gas_limit = eth_tester.get_block_by_number("latest")["gas_limit"]
+        after_gas_limit = eth_tester.get_block_by_number("latest")["gasLimit"]
         assert before_gas_limit == after_gas_limit
 
     #
@@ -400,7 +399,7 @@ class BaseTestBackendDirect:
 
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
         # assert that the raw transaction is confirmed and successful
-        assert receipt["transaction_hash"] == transaction_hash
+        assert receipt["transactionHash"] == transaction_hash
 
     def test_send_raw_transaction_invalid_rlp_transaction(self, eth_tester):
         self.skip_if_no_evm_execution()
@@ -470,10 +469,10 @@ class BaseTestBackendDirect:
         sent_transaction = eth_tester.get_transaction_by_hash(txn_hash)
 
         assert sent_transaction.get("type") == "0x2"
-        assert sent_transaction.get("max_fee_per_gas") == 1000000000
-        assert sent_transaction.get("max_priority_fee_per_gas") == 1000000000
-        assert sent_transaction.get("access_list") == ()
-        assert sent_transaction.get("gas_price") == 1000000000
+        assert sent_transaction.get("maxFeePerGas") == 1000000000
+        assert sent_transaction.get("maxPriorityFeePerGas") == 1000000000
+        assert sent_transaction.get("accessList") == ()
+        assert sent_transaction.get("gasPrice") == 1000000000
 
     def test_send_access_list_transaction(self, eth_tester):
         accounts = eth_tester.get_accounts()
@@ -492,7 +491,7 @@ class BaseTestBackendDirect:
         txn = eth_tester.get_transaction_by_hash(txn_hash)
 
         assert txn.get("type") == "0x1"
-        assert txn.get("access_list") == ()
+        assert txn.get("accessList") == ()
         self._check_transactions(access_list_transaction, txn)
 
         # with non-empty access list
@@ -533,7 +532,7 @@ class BaseTestBackendDirect:
         txn = eth_tester.get_transaction_by_hash(txn_hash)
 
         assert txn.get("type") == "0x2"
-        assert txn.get("access_list") == ()
+        assert txn.get("accessList") == ()
         self._check_transactions(dynamic_fee_transaction, txn)
 
         # with non-empty access list
@@ -554,7 +553,7 @@ class BaseTestBackendDirect:
         txn = eth_tester.get_transaction_by_hash(txn_hash)
 
         assert txn.get("type") == "0x2"
-        assert txn.get("access_list") != ()
+        assert txn.get("accessList") != ()
         self._check_transactions(dynamic_fee_transaction, txn)
 
     def test_block_number_auto_mine_transactions_enabled(self, eth_tester):
@@ -759,7 +758,7 @@ class BaseTestBackendDirect:
         )
         transaction = eth_tester.get_transaction_by_hash(transaction_hash)
         block = eth_tester.get_block_by_number(
-            transaction["block_number"],
+            transaction["blockNumber"],
             full_transactions=True,
         )
         assert is_dict(block["transactions"][0])
@@ -775,7 +774,7 @@ class BaseTestBackendDirect:
         )
         transaction = eth_tester.get_transaction_by_hash(transaction_hash)
         block = eth_tester.get_block_by_number(
-            transaction["block_number"],
+            transaction["blockNumber"],
             full_transactions=False,
         )
         assert is_hex(block["transactions"][0])
@@ -801,7 +800,7 @@ class BaseTestBackendDirect:
         )
         transaction = eth_tester.get_transaction_by_hash(transaction_hash)
         block = eth_tester.get_block_by_hash(
-            transaction["block_hash"],
+            transaction["blockHash"],
             full_transactions=True,
         )
         assert is_dict(block["transactions"][0])
@@ -817,7 +816,7 @@ class BaseTestBackendDirect:
         )
         transaction = eth_tester.get_transaction_by_hash(transaction_hash)
         block = eth_tester.get_block_by_hash(
-            transaction["block_hash"],
+            transaction["blockHash"],
             full_transactions=False,
         )
         assert is_hex(block["transactions"][0])
@@ -876,7 +875,7 @@ class BaseTestBackendDirect:
         )
         transaction = eth_tester.get_transaction_by_hash(transaction_hash)
         assert transaction["hash"] == transaction_hash
-        assert transaction["block_hash"] is None
+        assert transaction["blockHash"] is None
 
     def test_get_transaction_receipt_for_mined_transaction(self, eth_tester):
         transaction_hash = eth_tester.send_transaction(
@@ -888,9 +887,9 @@ class BaseTestBackendDirect:
         )
 
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
-        assert receipt["transaction_hash"] == transaction_hash
+        assert receipt["transactionHash"] == transaction_hash
         assert receipt["type"] == "0x2"
-        assert receipt["effective_gas_price"] == 1000000000
+        assert receipt["effectiveGasPrice"] == 1000000000
 
     @pytest.mark.parametrize(
         "type_specific_params,_type",
@@ -942,7 +941,7 @@ class BaseTestBackendDirect:
             )
         )
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
-        assert receipt["transaction_hash"] == transaction_hash
+        assert receipt["transactionHash"] == transaction_hash
         assert receipt["type"] == _type
 
     def test_receipt_effective_gas_price_for_mined_transaction_legacy(self, eth_tester):
@@ -957,9 +956,9 @@ class BaseTestBackendDirect:
             }
         )
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
-        assert receipt["transaction_hash"] == transaction_hash
+        assert receipt["transactionHash"] == transaction_hash
         assert receipt["type"] == "0x0"
-        assert receipt["effective_gas_price"] == gas_price
+        assert receipt["effectiveGasPrice"] == gas_price
 
     def test_receipt_effective_gas_price_for_mined_transaction_base_fee_minimum(
         self, eth_tester
@@ -977,18 +976,18 @@ class BaseTestBackendDirect:
         )
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
 
-        base_fee = eth_tester.get_block_by_number(receipt["block_number"])[
-            "base_fee_per_gas"
+        base_fee = eth_tester.get_block_by_number(receipt["blockNumber"])[
+            "baseFeePerGas"
         ]
 
         # base fee should be 875000000 since genesis was 1000000000
         assert base_fee == 875000000
 
-        assert receipt["transaction_hash"] == transaction_hash
+        assert receipt["transactionHash"] == transaction_hash
         assert receipt["type"] == "0x2"
         # the max fee is higher than (base fee + priority fee) so the latter should be
         # the effective gas price
-        assert receipt["effective_gas_price"] == base_fee + priority_fee
+        assert receipt["effectiveGasPrice"] == base_fee + priority_fee
 
     def test_receipt_effective_gas_price_for_mined_transaction_max_fee_minimum(
         self, eth_tester
@@ -1007,18 +1006,18 @@ class BaseTestBackendDirect:
         )
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
 
-        base_fee = eth_tester.get_block_by_number(receipt["block_number"])[
-            "base_fee_per_gas"
+        base_fee = eth_tester.get_block_by_number(receipt["blockNumber"])[
+            "baseFeePerGas"
         ]
 
         # base fee should be 875000000 since genesis was 1000000000
         assert base_fee == 875000000
 
-        assert receipt["transaction_hash"] == transaction_hash
+        assert receipt["transactionHash"] == transaction_hash
         assert receipt["type"] == "0x2"
         # the max fee is lower than (base fee + priority fee) so the former should be
         # the effective gas price
-        assert receipt["effective_gas_price"] == max_fee
+        assert receipt["effectiveGasPrice"] == max_fee
 
     def test_get_transaction_receipt_for_unmined_transaction_raises(self, eth_tester):
         eth_tester.disable_auto_mine_transactions()
@@ -1100,11 +1099,11 @@ class BaseTestBackendDirect:
         )
         transaction_hash = eth_tester.send_transaction(call_math_transaction)
         receipt = eth_tester.get_transaction_receipt(transaction_hash)
-        assert receipt["gas_used"] <= gas_estimation
+        assert receipt["gasUsed"] <= gas_estimation
         # Tolerance set to the default py-evm tolerance:
         # https://github.com/ethereum/py-evm/blob/f0276e684edebd7cd9e84cd04b3229ab9dd958b9/evm/estimators/gas.py#L77
         # https://github.com/ethereum/py-evm/blob/f0276e684edebd7cd9e84cd04b3229ab9dd958b9/evm/estimators/__init__.py#L11
-        assert receipt["gas_used"] >= gas_estimation - 21000
+        assert receipt["gasUsed"] >= gas_estimation - 21000
 
     def test_estimate_gas_with_block_identifier(self, eth_tester):
         self.skip_if_no_evm_execution()
@@ -1268,7 +1267,7 @@ class BaseTestBackendDirect:
         )
         fork_a_transaction_block_hash = eth_tester.get_transaction_by_hash(
             fork_a_transaction_hash,
-        )["block_hash"]
+        )["blockHash"]
         fork_a_blocks = eth_tester.mine_blocks(2)
 
         before_revert_changes_logs_a = eth_tester.get_only_filter_changes(filter_a_id)
@@ -1305,7 +1304,7 @@ class BaseTestBackendDirect:
         )
         fork_b_transaction_block_hash = eth_tester.get_transaction_by_hash(
             fork_b_transaction_hash,
-        )["block_hash"]
+        )["blockHash"]
         fork_b_blocks = eth_tester.mine_blocks(2)
 
         # check that are blocks don't intersect
@@ -1795,9 +1794,9 @@ class BaseTestBackendDirect:
         cumulative_gas_used = 0
         for tx_hash in tx_hashes:
             receipt = eth_tester.get_transaction_receipt(tx_hash)
-            cumulative_gas_used += receipt["gas_used"]
-            assert receipt["gas_used"] == 21000
-            assert receipt["cumulative_gas_used"] == cumulative_gas_used
+            cumulative_gas_used += receipt["gasUsed"]
+            assert receipt["gasUsed"] == 21000
+            assert receipt["cumulativeGasUsed"] == cumulative_gas_used
 
     #
     # Time Travel

--- a/eth_tester/utils/emitter_contract.py
+++ b/eth_tester/utils/emitter_contract.py
@@ -248,7 +248,7 @@ def _deploy_emitter(eth_tester):
         }
     )
     deploy_receipt = eth_tester.get_transaction_receipt(deploy_hash)
-    emitter_address = deploy_receipt["contract_address"]
+    emitter_address = deploy_receipt["contractAddress"]
     assert emitter_address
     return emitter_address
 

--- a/eth_tester/utils/math_contract.py
+++ b/eth_tester/utils/math_contract.py
@@ -108,7 +108,7 @@ def _deploy_math(eth_tester):
         }
     )
     deploy_receipt = eth_tester.get_transaction_receipt(deploy_hash)
-    math_address = deploy_receipt["contract_address"]
+    math_address = deploy_receipt["contractAddress"]
     assert math_address
     math_code = eth_tester.get_code(math_address)
     assert len(math_code) > 2

--- a/eth_tester/utils/throws_contract.py
+++ b/eth_tester/utils/throws_contract.py
@@ -112,7 +112,7 @@ def _deploy_throws(eth_tester, contract_name):
         }
     )
     deploy_receipt = eth_tester.get_transaction_receipt(deploy_hash)
-    throws_address = deploy_receipt["contract_address"]
+    throws_address = deploy_receipt["contractAddress"]
     assert throws_address
     throws_code = eth_tester.get_code(throws_address)
     assert len(throws_code) > 2

--- a/tests/core/normalization/conftest.py
+++ b/tests/core/normalization/conftest.py
@@ -1,0 +1,122 @@
+from typing import (
+    Any,
+    Dict,
+)
+
+import pytest
+
+from tests.utils import (
+    ZERO_ADDRESS,
+    Block,
+    LogEntry,
+    Receipt,
+    Transaction,
+)
+
+
+# Transaction fixtures
+@pytest.fixture
+def transaction() -> Dict[str, Any]:
+    return dict(Transaction())
+
+
+@pytest.fixture
+def transaction_with_auth_list() -> Dict[str, Any]:
+    return dict(
+        Transaction(
+            authorization_list=(
+                {
+                    "chain_id": 1,
+                    "address": ZERO_ADDRESS,
+                    "nonce": 0,
+                    "y_parity": 0,
+                    "r": 0,
+                    "s": 0,
+                },
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def transaction_with_access_list() -> Dict[str, Any]:
+    return dict(
+        Transaction(
+            access_list=(
+                (
+                    ZERO_ADDRESS,
+                    b"\x00" * 32,
+                ),
+            ),
+        )
+    )
+
+
+# Block fixtures
+@pytest.fixture
+def block() -> Dict[str, Any]:
+    return dict(Block())
+
+
+@pytest.fixture
+def block_with_transactions() -> Dict[str, Any]:
+    return dict(
+        Block(
+            transactions=(
+                dict(Transaction(hash=b"\x00" * 32)),
+                dict(Transaction(hash=b"\x01" * 32)),
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def block_with_transaction_hashes() -> Dict[str, Any]:
+    return dict(
+        Block(
+            transactions=(
+                b"\x00" * 32,
+                b"\x01" * 32,
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def block_with_withdrawals() -> Dict[str, Any]:
+    return dict(
+        Block(
+            withdrawals=(
+                {
+                    "index": 0,
+                    "validator_index": 0,
+                    "amount": 0,
+                    "address": ZERO_ADDRESS,
+                },
+            ),
+        )
+    )
+
+
+# LogEntry fixtures
+@pytest.fixture
+def log_entry() -> Dict[str, Any]:
+    return dict(LogEntry())
+
+
+# Receipt fixtures
+@pytest.fixture
+def receipt() -> Dict[str, Any]:
+    return dict(Receipt())
+
+
+@pytest.fixture
+def receipt_with_logs() -> Dict[str, Any]:
+    return dict(
+        Receipt(
+            logs=(
+                dict(LogEntry(transaction_hash=b"\x00" * 32)),
+                dict(LogEntry(transaction_hash=b"\x01" * 32)),
+            ),
+        )
+    )

--- a/tests/core/normalization/test_default_outbound_normalization.py
+++ b/tests/core/normalization/test_default_outbound_normalization.py
@@ -77,7 +77,6 @@ def test_outbound_transaction_keys_normalization(transaction: Transaction) -> No
         "maxPriorityFeePerGas",
         "data",
         "accessList",
-        "authorizationList",
         "r",
         "s",
         "v",
@@ -101,25 +100,6 @@ def test_outbound_transaction_access_list_keys_normalization(
     assert sorted(list(dict(normalized_transaction["accessList"][0]).keys())) == sorted(
         expected_access_list_keys
     )
-
-
-def test_outbound_transaction_auth_list_keys_normalization(
-    transaction_with_auth_list: Transaction,
-) -> None:
-    normalized_transaction = DefaultNormalizer.normalize_outbound_transaction(
-        transaction_with_auth_list
-    )
-    expected_auth_list_keys = [
-        "chainId",
-        "address",
-        "nonce",
-        "yParity",
-        "r",
-        "s",
-    ]
-    assert sorted(
-        list(dict(normalized_transaction["authorizationList"][0]).keys())
-    ) == sorted(expected_auth_list_keys)
 
 
 def test_outbound_block_keys_normalization(block: Block) -> None:
@@ -152,7 +132,6 @@ def test_outbound_block_keys_normalization(block: Block) -> None:
         "parentBeaconBlockRoot",
         "blobGasUsed",
         "excessBlobGas",
-        "requestsHash",
     ]
     assert sorted(list(dict(normalized_block).keys())) == sorted(expected_block_keys)
 
@@ -183,7 +162,6 @@ def test_outbound_block_transaction_object_keys_normalization(
         "maxPriorityFeePerGas",
         "data",
         "accessList",
-        "authorizationList",
         "r",
         "s",
         "v",

--- a/tests/core/normalization/test_default_outbound_normalization.py
+++ b/tests/core/normalization/test_default_outbound_normalization.py
@@ -3,6 +3,10 @@ from eth_utils import (
     to_checksum_address,
 )
 
+from eth_tester.constants import (
+    BLANK_ROOT_HASH,
+    ZERO_ADDRESS_HEX,
+)
 from eth_tester.normalization import (
     DefaultNormalizer,
 )
@@ -13,6 +17,7 @@ from tests.core.validation.test_outbound_validation import (
     _make_dynamic_fee_txn,
 )
 from tests.utils import (
+    ZERO_ADDRESS,
     make_receipt,
 )
 
@@ -120,8 +125,8 @@ def test_outbound_transaction_normalization() -> None:
         "blockHash": "0x" + "00" * 32,
         "blockNumber": 0,
         "transactionIndex": 0,
-        "from": "0x0000000000000000000000000000000000000000",
-        "to": "0x0000000000000000000000000000000000000000",
+        "from": ZERO_ADDRESS_HEX,
+        "to": ZERO_ADDRESS_HEX,
         "value": 0,
         "gas": 21000,
         "gasPrice": 1,
@@ -131,7 +136,7 @@ def test_outbound_transaction_normalization() -> None:
         "data": "0x",
         "accessList": (
             {
-                "address": "0x0000000000000000000000000000000000000000",
+                "address": ZERO_ADDRESS_HEX,
                 "storageKeys": (
                     "0x" + "00" * 31 + "01",
                     "0x" + "00" * 31 + "02",
@@ -143,7 +148,7 @@ def test_outbound_transaction_normalization() -> None:
         "authorizationList": (
             {
                 "chainId": 1,
-                "address": "0x0000000000000000000000000000000000000000",
+                "address": ZERO_ADDRESS_HEX,
                 "nonce": 0,
                 "yParity": 0,
                 "r": 0,
@@ -156,3 +161,189 @@ def test_outbound_transaction_normalization() -> None:
         "yParity": 0,
     }
     assert normalized_transaction == expected_normalized_transaction
+
+
+def test_outbound_block_normalization() -> None:
+    block = {
+        "number": 1,
+        "hash": b"\x00" * 32,
+        "parent_hash": b"\x00" * 32,
+        "nonce": b"\x00" * 8,
+        "base_fee_per_gas": 0,
+        "sha3_uncles": b"\x00" * 32,
+        "logs_bloom": 0,
+        "transactions_root": b"\x00" * 32,
+        "receipts_root": b"\x00" * 32,
+        "state_root": b"\x00" * 32,
+        "coinbase": b"\x00" * 20,
+        "difficulty": 0,
+        "mix_hash": b"\x00" * 32,
+        "total_difficulty": 0,
+        "size": 0,
+        "extra_data": b"\x00" * 32,
+        "gas_limit": 0,
+        "gas_used": 0,
+        "timestamp": 0,
+        "transactions": (
+            b"\x00" * 32,
+            b"\x00" * 32,
+        ),
+        "uncles": (
+            b"\x00" * 32,
+            b"\x00" * 32,
+        ),
+        "withdrawals": (
+            {
+                "index": 0,
+                "validator_index": 0,
+                "amount": 0,
+                "address": b"\x00" * 20,
+            },
+        ),
+        "withdrawals_root": b"\x00" * 32,
+        "parent_beacon_block_root": b"\x00" * 32,
+        "blob_gas_used": 0,
+        "excess_blob_gas": 0,
+        "requests_hash": b"\x00" * 32,
+    }
+
+    normalized_block = DefaultNormalizer.normalize_outbound_block(block)
+    expected_normalized_block = {
+        "number": 1,
+        "hash": "0x" + "00" * 32,
+        "parentHash": "0x" + "00" * 32,
+        "nonce": "0x" + "00" * 8,
+        "baseFeePerGas": 0,
+        "sha3Uncles": "0x" + "00" * 32,
+        "logsBloom": 0,
+        "transactionsRoot": "0x" + "00" * 32,
+        "receiptsRoot": "0x" + "00" * 32,
+        "stateRoot": "0x" + "00" * 32,
+        "coinbase": ZERO_ADDRESS_HEX,
+        "difficulty": 0,
+        "mixHash": "0x" + "00" * 32,
+        "totalDifficulty": 0,
+        "size": 0,
+        "extraData": "0x" + "00" * 32,
+        "gasLimit": 0,
+        "gasUsed": 0,
+        "timestamp": 0,
+        "transactions": (
+            "0x" + "00" * 32,
+            "0x" + "00" * 32,
+        ),
+        "uncles": (
+            "0x" + "00" * 32,
+            "0x" + "00" * 32,
+        ),
+        "withdrawals": (
+            {
+                "index": 0,
+                "validatorIndex": 0,
+                "amount": 0,
+                "address": ZERO_ADDRESS_HEX,
+            },
+        ),
+        "withdrawalsRoot": "0x" + "00" * 32,
+        "parentBeaconBlockRoot": "0x" + "00" * 32,
+        "blobGasUsed": 0,
+        "excessBlobGas": 0,
+        "requestsHash": "0x" + "00" * 32,
+    }
+    assert normalized_block == expected_normalized_block
+
+
+def test_outbound_log_entry_normalization() -> None:
+    log_entry = {
+        "type": 1,
+        "log_index": 0,
+        "transaction_index": 0,
+        "transaction_hash": b"\x00" * 32,
+        "block_hash": b"\x00" * 32,
+        "block_number": 0,
+        "address": b"\x00" * 20,
+        "data": b"\x00" * 32,
+        "topics": (
+            b"\x00" * 32,
+            b"\x00" * 32,
+        ),
+    }
+
+    normalized_log_entry = DefaultNormalizer.normalize_outbound_log_entry(log_entry)
+    expected_normalized_log_entry = {
+        "type": 1,
+        "logIndex": 0,
+        "transactionIndex": 0,
+        "transactionHash": "0x" + "00" * 32,
+        "blockHash": "0x" + "00" * 32,
+        "blockNumber": 0,
+        "address": ZERO_ADDRESS_HEX,
+        "data": "0x" + "00" * 32,
+        "topics": (
+            "0x" + "00" * 32,
+            "0x" + "00" * 32,
+        ),
+    }
+    assert normalized_log_entry == expected_normalized_log_entry
+
+
+def test_outbound_receipt_normalization() -> None:
+    receipt = {
+        "transaction_hash": b"\x00" * 32,
+        "transaction_index": 0,
+        "block_number": 0,
+        "block_hash": b"\x00" * 32,
+        "cumulative_gas_used": 21000,
+        "effective_gas_price": 1,
+        "from": b"\x00" * 20,
+        "gas_used": 21000,
+        "contract_address": b"\x00" * 20,
+        "logs": (
+            {
+                "address": b"\x00" * 20,
+                "data": b"\x00" * 32,
+                "topics": (
+                    b"\x00" * 32,
+                    b"\x00" * 32,
+                ),
+            },
+        ),
+        "state_root": BLANK_ROOT_HASH,
+        "status": 1,
+        "to": b"\x00" * 20,
+        "type": 1,
+        "base_fee_per_gas": 1,
+        "blob_gas_used": 1,
+        "blob_gas_price": 1,
+    }
+
+    normalized_receipt = DefaultNormalizer.normalize_outbound_receipt(receipt)
+    expected_normalized_receipt = {
+        "transactionHash": "0x" + "00" * 32,
+        "transactionIndex": 0,
+        "blockNumber": 0,
+        "blockHash": "0x" + "00" * 32,
+        "cumulativeGasUsed": 21000,
+        "effectiveGasPrice": 1,
+        "from": ZERO_ADDRESS_HEX,
+        "gasUsed": 21000,
+        "contractAddress": ZERO_ADDRESS_HEX,
+        "logs": (
+            {
+                "address": ZERO_ADDRESS_HEX,
+                "data": "0x" + "00" * 32,
+                "topics": (
+                    "0x" + "00" * 32,
+                    "0x" + "00" * 32,
+                ),
+            },
+        ),
+        "stateRoot": BLANK_ROOT_HASH,
+        "status": 1,
+        "to": ZERO_ADDRESS_HEX,
+        "type": "0x1",
+        "baseFeePerGas": 1,
+        "blobGasUsed": 1,
+        "blobGasPrice": 1,
+    }
+    assert normalized_receipt == expected_normalized_receipt

--- a/tests/core/normalization/test_default_outbound_normalization.py
+++ b/tests/core/normalization/test_default_outbound_normalization.py
@@ -1,7 +1,16 @@
 import pytest
+from eth_utils import (
+    to_checksum_address,
+)
 
 from eth_tester.normalization import (
     DefaultNormalizer,
+)
+from tests.core.validation.test_inbound_validation import (
+    _make_transaction,
+)
+from tests.core.validation.test_outbound_validation import (
+    _make_dynamic_fee_txn,
 )
 from tests.utils import (
     make_receipt,
@@ -41,3 +50,109 @@ def test_outbound_receipt_contract_address_status_based_normalization(
 )
 def test_outbound_storage_normalization(value, expected):
     assert DefaultNormalizer.normalize_outbound_storage(value) == expected
+
+
+def test_outbound_transaction_normalization() -> None:
+    transaction = {
+        "type": 2,
+        "blob_versioned_hashes": (
+            b"\x00" * 32,
+            b"\x00" * 32,
+            b"\x00" * 32,
+            b"\x00" * 32,
+        ),
+        "chain_id": 131277322940537,
+        "hash": b"\x00" * 32,
+        "nonce": 0,
+        "block_hash": b"\x00" * 32,
+        "block_number": 0,
+        "transaction_index": 0,
+        "from": b"\x00" * 20,
+        "to": b"\x00" * 20,
+        "value": 0,
+        "gas": 21000,
+        "gas_price": 1,
+        "max_fee_per_blob_gas": 1,
+        "max_fee_per_gas": 2000000000,
+        "max_priority_fee_per_gas": 1000000000,
+        "data": b"",
+        "access_list": (
+            (
+                b"\x00" * 20,
+                (
+                    0x01,
+                    0x02,
+                    0x03,
+                    0x04,
+                ),
+            ),
+        ),
+        "authorization_list": (
+            {
+                "chain_id": 1,
+                "address": b"\x00" * 20,
+                "nonce": 0,
+                "y_parity": 0,
+                "r": 0,
+                "s": 0,
+            },
+        ),
+        "r": 0,
+        "s": 0,
+        "v": 0,
+        "y_parity": 0,
+    }
+    normalized_transaction = DefaultNormalizer.normalize_outbound_transaction(
+        transaction
+    )
+
+    expected_normalized_transaction = {
+        "type": "0x2",
+        "blobVersionedHashes": (
+            "0x" + "00" * 32,
+            "0x" + "00" * 32,
+            "0x" + "00" * 32,
+            "0x" + "00" * 32,
+        ),
+        "chainId": 131277322940537,
+        "hash": "0x" + "00" * 32,
+        "nonce": 0,
+        "blockHash": "0x" + "00" * 32,
+        "blockNumber": 0,
+        "transactionIndex": 0,
+        "from": "0x0000000000000000000000000000000000000000",
+        "to": "0x0000000000000000000000000000000000000000",
+        "value": 0,
+        "gas": 21000,
+        "gasPrice": 1,
+        "maxFeePerBlobGas": 1,
+        "maxFeePerGas": 2000000000,
+        "maxPriorityFeePerGas": 1000000000,
+        "data": "0x",
+        "accessList": (
+            {
+                "address": "0x0000000000000000000000000000000000000000",
+                "storageKeys": (
+                    "0x" + "00" * 31 + "01",
+                    "0x" + "00" * 31 + "02",
+                    "0x" + "00" * 31 + "03",
+                    "0x" + "00" * 31 + "04",
+                ),
+            },
+        ),
+        "authorizationList": (
+            {
+                "chainId": 1,
+                "address": "0x0000000000000000000000000000000000000000",
+                "nonce": 0,
+                "yParity": 0,
+                "r": 0,
+                "s": 0,
+            },
+        ),
+        "r": 0,
+        "s": 0,
+        "v": 0,
+        "yParity": 0,
+    }
+    assert normalized_transaction == expected_normalized_transaction

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -84,7 +84,6 @@ class Transaction:
         max_priority_fee_per_gas: int = 1000000000,
         data: bytes = b"",
         access_list: tuple[tuple[bytes, ...], ...] = (),
-        authorization_list: tuple[Dict[str, Any], ...] = (),
         r: int = 0,
         s: int = 0,
         v: int = 0,
@@ -108,7 +107,6 @@ class Transaction:
         self.max_priority_fee_per_gas = max_priority_fee_per_gas
         self.data = data
         self.access_list = access_list
-        self.authorization_list = authorization_list
         self.r = r
         self.s = s
         self.v = v
@@ -161,7 +159,6 @@ class Block:
         parent_beacon_block_root: bytes = b"",
         blob_gas_used: int = 0,
         excess_blob_gas: int = 0,
-        requests_hash: bytes = b"",
     ):
         self.number = number
         self.hash = hash
@@ -189,7 +186,6 @@ class Block:
         self.parent_beacon_block_root = parent_beacon_block_root
         self.blob_gas_used = blob_gas_used
         self.excess_blob_gas = excess_blob_gas
-        self.requests_hash = requests_hash
 
     def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,10 @@
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Tuple,
+)
+
 from eth_utils import (
     to_dict,
 )
@@ -50,3 +57,237 @@ def make_receipt(
     yield from yield_key_value_if_value_not_none("contract_address", contract_address)
     yield from yield_key_value_if_value_not_none("blob_gas_used", blob_gas_used)
     yield from yield_key_value_if_value_not_none("blob_gas_price", blob_gas_price)
+
+
+class Transaction:
+    """
+    Transaction class to represent a transaction object for use in testing.
+    """
+
+    def __init__(
+        self,
+        _type: int = 0,
+        blob_versioned_hashes: tuple[bytes, ...] = (),
+        chain_id: int = 131277322940537,
+        hash: bytes = b"",
+        nonce: int = 0,
+        block_hash: bytes = b"",
+        block_number: int = 0,
+        transaction_index: int = 0,
+        _from: bytes = ZERO_ADDRESS,
+        to: bytes = ZERO_ADDRESS,
+        value: int = 0,
+        gas: int = 21000,
+        gas_price: int = 1,
+        max_fee_per_blob_gas: int = 1,
+        max_fee_per_gas: int = 2000000000,
+        max_priority_fee_per_gas: int = 1000000000,
+        data: bytes = b"",
+        access_list: tuple[tuple[bytes, ...], ...] = (),
+        authorization_list: tuple[Dict[str, Any], ...] = (),
+        r: int = 0,
+        s: int = 0,
+        v: int = 0,
+        y_parity: int = 0,
+    ):
+        self.type = _type
+        self.blob_versioned_hashes = blob_versioned_hashes
+        self.chain_id = chain_id
+        self.hash = hash
+        self.nonce = nonce
+        self.block_hash = block_hash
+        self.block_number = block_number
+        self.transaction_index = transaction_index
+        self._from = _from
+        self.to = to
+        self.value = value
+        self.gas = gas
+        self.gas_price = gas_price
+        self.max_fee_per_blob_gas = max_fee_per_blob_gas
+        self.max_fee_per_gas = max_fee_per_gas
+        self.max_priority_fee_per_gas = max_priority_fee_per_gas
+        self.data = data
+        self.access_list = access_list
+        self.authorization_list = authorization_list
+        self.r = r
+        self.s = s
+        self.v = v
+        self.y_parity = y_parity
+
+    def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
+        """
+        Yield key, value pairs of the Transaction object attributes
+        """
+        yield from (
+            (
+                "from" if key == "_from" else key,
+                value,
+            )
+            for key, value in self.__dict__.items()
+            if value is not None
+        )
+
+
+class Block:
+    """
+    Block class to represent a block object for use in testing.
+    """
+
+    def __init__(
+        self,
+        number: int = 0,
+        hash: bytes = b"",
+        parent_hash: bytes = b"",
+        nonce: bytes = b"",
+        base_fee_per_gas: int = 0,
+        sha3_uncles: bytes = b"",
+        logs_bloom: bytes = b"",
+        transactions_root: bytes = b"",
+        receipts_root: bytes = b"",
+        state_root: bytes = b"",
+        coinbase: bytes = ZERO_ADDRESS,
+        difficulty: int = 0,
+        mix_hash: bytes = b"",
+        total_difficulty: int = 0,
+        size: int = 0,
+        extra_data: bytes = b"",
+        gas_limit: int = 0,
+        gas_used: int = 0,
+        timestamp: int = 0,
+        transactions: tuple[bytes | dict[str, Any], ...] = (),
+        uncles: tuple[bytes, ...] = (),
+        withdrawals: tuple[Dict[str, Any], ...] = (),
+        withdrawals_root: bytes = b"",
+        parent_beacon_block_root: bytes = b"",
+        blob_gas_used: int = 0,
+        excess_blob_gas: int = 0,
+        requests_hash: bytes = b"",
+    ):
+        self.number = number
+        self.hash = hash
+        self.parent_hash = parent_hash
+        self.nonce = nonce
+        self.base_fee_per_gas = base_fee_per_gas
+        self.sha3_uncles = sha3_uncles
+        self.logs_bloom = logs_bloom
+        self.transactions_root = transactions_root
+        self.receipts_root = receipts_root
+        self.state_root = state_root
+        self.coinbase = coinbase
+        self.difficulty = difficulty
+        self.mix_hash = mix_hash
+        self.total_difficulty = total_difficulty
+        self.size = size
+        self.extra_data = extra_data
+        self.gas_limit = gas_limit
+        self.gas_used = gas_used
+        self.timestamp = timestamp
+        self.transactions = transactions
+        self.uncles = uncles
+        self.withdrawals = withdrawals
+        self.withdrawals_root = withdrawals_root
+        self.parent_beacon_block_root = parent_beacon_block_root
+        self.blob_gas_used = blob_gas_used
+        self.excess_blob_gas = excess_blob_gas
+        self.requests_hash = requests_hash
+
+    def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
+        """
+        Yield key, value pairs of the Block object attributes
+        """
+        yield from (
+            (key, value) for key, value in self.__dict__.items() if value is not None
+        )
+
+
+class LogEntry:
+    """
+    LogEntry class to represent a log entry object for use in testing.
+    """
+
+    def __init__(
+        self,
+        _type: int = 0,
+        log_index: int = 0,
+        transaction_index: int = 0,
+        transaction_hash: bytes = b"",
+        block_hash: bytes = b"",
+        block_number: int = 0,
+        address: bytes = ZERO_ADDRESS,
+        data: bytes = b"",
+        topics: tuple[bytes, ...] = (),
+    ):
+        self.type = _type
+        self.log_index = log_index
+        self.transaction_index = transaction_index
+        self.transaction_hash = transaction_hash
+        self.block_hash = block_hash
+        self.block_number = block_number
+        self.address = address
+        self.data = data
+        self.topics = topics
+
+    def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
+        """
+        Yield key, value pairs of the LogEntry object attributes
+        """
+        yield from (
+            (key, value) for key, value in self.__dict__.items() if value is not None
+        )
+
+
+class Receipt:
+    """
+    Receipt class to represent a receipt object for use in testing.
+    """
+
+    def __init__(
+        self,
+        transaction_hash: bytes = b"",
+        transaction_index: int = 0,
+        block_number: int = 0,
+        block_hash: bytes = b"",
+        cumulative_gas_used: int = 0,
+        effective_gas_price: int = 0,
+        _from: bytes = ZERO_ADDRESS,
+        gas_used: int = 0,
+        contract_address: bytes = ZERO_ADDRESS,
+        logs: tuple[Dict[str, Any], ...] = (),
+        state_root: bytes = b"",
+        status: int = 1,
+        to: bytes = ZERO_ADDRESS,
+        _type: int = 0,
+        base_fee_per_gas: int = 0,
+        blob_gas_used: int = 0,
+        blob_gas_price: int = 0,
+    ):
+        self.transaction_hash = transaction_hash
+        self.transaction_index = transaction_index
+        self.block_number = block_number
+        self.block_hash = block_hash
+        self.cumulative_gas_used = cumulative_gas_used
+        self.effective_gas_price = effective_gas_price
+        self._from = _from
+        self.gas_used = gas_used
+        self.contract_address = contract_address
+        self.logs = logs
+        self.state_root = state_root
+        self.status = status
+        self.to = to
+        self._type = _type
+        self.base_fee_per_gas = base_fee_per_gas
+        self.blob_gas_used = blob_gas_used
+        self.blob_gas_price = blob_gas_price
+
+    def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
+        """
+        Yield key, value pairs of the Receipt object attributes
+        """
+        yield from (
+            (
+                "from" if key == "_from" else "type" if key == "_type" else key,
+                value,
+            )
+            for key, value in self.__dict__.items()
+            if value is not None
+        )


### PR DESCRIPTION
### What was wrong?

Closes #324

### How was it fixed?

Traverse outbound dicts recursively to normalize all the keys to camelCase. Includes tests and typing improvements around outbound tests.

### Todo:

- [X] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
