### PR TITLE
Return camelCase keys from serializers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,18 +305,7 @@ jobs:
         environment:
           TOXENV: py313-pyevm
 
-  py38-eels:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-eels
-  py39-eels:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-eels
+  # eels only supported on Python 3.10+
   py310-eels:
     <<: *common
     docker:
@@ -371,8 +360,6 @@ define: &all_jobs
   - py311-pyevm
   - py312-pyevm
   - py313-pyevm
-  - py38-eels
-  - py39-eels
   - py310-eels
   - py311-eels
   - py312-eels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,43 @@ jobs:
         environment:
           TOXENV: py313-pyevm
 
+  py38-eels:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-eels
+  py39-eels:
+    <<: *common
+    docker:
+      - image: cimg/python:3.9
+        environment:
+          TOXENV: py39-eels
+  py310-eels:
+    <<: *common
+    docker:
+      - image: cimg/python:3.10
+        environment:
+          TOXENV: py310-eels
+  py311-eels:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-eels
+  py312-eels:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-eels
+  py313-eels:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-eels
+
 define: &all_jobs
   - docs
   - py38-core
@@ -334,6 +371,12 @@ define: &all_jobs
   - py311-pyevm
   - py312-pyevm
   - py313-pyevm
+  - py38-eels
+  - py39-eels
+  - py310-eels
+  - py311-eels
+  - py312-eels
+  - py313-eels
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -695,13 +695,14 @@ various backends by default.  You can however install ethereum tester with the
 necessary dependencies using the following method.
 
 ```bash
-$ python -m pip install eth-tester[<backend-name>]
+$ python -m pip install "eth-tester[<backend-name>]"
 ```
 
 You should replace `<backend-name>` with the name of the desired testing
 backend.  Available backends are:
 
 - `py-evm`: [PyEVM (alpha)](https://pypi.python.org/pypi/py-evm) **(experimental)**
+- `eels`: [EELS](https://pypi.org/project/ethereum-execution/)
 
 ### Selecting a Backend
 

--- a/eth_tester/backends/eels/main.py
+++ b/eth_tester/backends/eels/main.py
@@ -1,9 +1,9 @@
-import copy
-import os
-import time
 from contextlib import (
     contextmanager,
 )
+import copy
+import os
+import time
 from typing import (
     Any,
     Dict,
@@ -70,7 +70,8 @@ if eels_is_available():
     )
 else:
 
-    class BlockChain: ...
+    class BlockChain:
+        ...
 
     ForkLoad = None
     TransactionLoad = None
@@ -293,10 +294,10 @@ class EELSBackend(BaseChainBackend):
             )
 
         if self.fork.is_after_fork("ethereum.cancun"):
-            genesis_state[BEACON_ROOTS_CONTRACT_ADDRESS] = (
-                self._get_default_account_state(
-                    overrides={"code": BEACON_ROOTS_CONTRACT_CODE}
-                )
+            genesis_state[
+                BEACON_ROOTS_CONTRACT_ADDRESS
+            ] = self._get_default_account_state(
+                overrides={"code": BEACON_ROOTS_CONTRACT_CODE}
             )
 
         eels_state = self._fork_module.State()
@@ -535,15 +536,15 @@ class EELSBackend(BaseChainBackend):
                         self.fork.encode_transaction(tx),
                     )
 
-                    apply_body_output_dict["receipts_map"][self._get_tx_hash(tx)] = (
-                        serialize_pending_receipt(
-                            self,
-                            tx,
-                            process_transaction_return,
-                            i,
-                            int(block_gas_limit - gas_available),
-                            contract_address,
-                        )
+                    apply_body_output_dict["receipts_map"][
+                        self._get_tx_hash(tx)
+                    ] = serialize_pending_receipt(
+                        self,
+                        tx,
+                        process_transaction_return,
+                        i,
+                        int(block_gas_limit - gas_available),
+                        contract_address,
                     )
 
                     receipt = self.fork.make_receipt(
@@ -594,9 +595,9 @@ class EELSBackend(BaseChainBackend):
 
             if self.fork.is_after_fork("ethereum.cancun"):
                 apply_body_output_dict["blob_gas_used"] = blob_gas_used
-                apply_body_output_dict["excess_blob_gas"] = (
-                    self._vm_module.gas.calculate_excess_blob_gas(latest_block_header)
-                )
+                apply_body_output_dict[
+                    "excess_blob_gas"
+                ] = self._vm_module.gas.calculate_excess_blob_gas(latest_block_header)
 
             apply_body_output_dict["state_root"] = self.fork.state_root(current_state)
             apply_body_output_dict["tx_root"] = self.fork.root(transactions_trie)

--- a/eth_tester/backends/eels/main.py
+++ b/eth_tester/backends/eels/main.py
@@ -1,9 +1,9 @@
-from contextlib import (
-    contextmanager,
-)
 import copy
 import os
 import time
+from contextlib import (
+    contextmanager,
+)
 from typing import (
     Any,
     Dict,
@@ -70,8 +70,7 @@ if eels_is_available():
     )
 else:
 
-    class BlockChain:
-        ...
+    class BlockChain: ...
 
     ForkLoad = None
     TransactionLoad = None
@@ -294,10 +293,10 @@ class EELSBackend(BaseChainBackend):
             )
 
         if self.fork.is_after_fork("ethereum.cancun"):
-            genesis_state[
-                BEACON_ROOTS_CONTRACT_ADDRESS
-            ] = self._get_default_account_state(
-                overrides={"code": BEACON_ROOTS_CONTRACT_CODE}
+            genesis_state[BEACON_ROOTS_CONTRACT_ADDRESS] = (
+                self._get_default_account_state(
+                    overrides={"code": BEACON_ROOTS_CONTRACT_CODE}
+                )
             )
 
         eels_state = self._fork_module.State()
@@ -536,15 +535,15 @@ class EELSBackend(BaseChainBackend):
                         self.fork.encode_transaction(tx),
                     )
 
-                    apply_body_output_dict["receipts_map"][
-                        self._get_tx_hash(tx)
-                    ] = serialize_pending_receipt(
-                        self,
-                        tx,
-                        process_transaction_return,
-                        i,
-                        int(block_gas_limit - gas_available),
-                        contract_address,
+                    apply_body_output_dict["receipts_map"][self._get_tx_hash(tx)] = (
+                        serialize_pending_receipt(
+                            self,
+                            tx,
+                            process_transaction_return,
+                            i,
+                            int(block_gas_limit - gas_available),
+                            contract_address,
+                        )
                     )
 
                     receipt = self.fork.make_receipt(
@@ -595,9 +594,9 @@ class EELSBackend(BaseChainBackend):
 
             if self.fork.is_after_fork("ethereum.cancun"):
                 apply_body_output_dict["blob_gas_used"] = blob_gas_used
-                apply_body_output_dict[
-                    "excess_blob_gas"
-                ] = self._vm_module.gas.calculate_excess_blob_gas(latest_block_header)
+                apply_body_output_dict["excess_blob_gas"] = (
+                    self._vm_module.gas.calculate_excess_blob_gas(latest_block_header)
+                )
 
             apply_body_output_dict["state_root"] = self.fork.state_root(current_state)
             apply_body_output_dict["tx_root"] = self.fork.root(transactions_trie)

--- a/eth_tester/backends/eels/serializers.py
+++ b/eth_tester/backends/eels/serializers.py
@@ -36,17 +36,19 @@ from eth_tester.utils.transactions import (
 def _serialize_withdrawals_to_block(serialized_block, withdrawals):
     txn_withdrawals = []
     for withdrawal in withdrawals:
-        txn_withdrawals.append(
-            {
-                "index": int(withdrawal.index),
-                "validatorIndex": int(withdrawal.validator_index),
-                "address": withdrawal.address,
-                "amount": int(withdrawal.amount),
-            }
-        )
+        txn_withdrawals.append(serialize_eels_withdrawal_for_block(withdrawal))
 
     serialized_block["withdrawals"] = txn_withdrawals
     return serialized_block
+
+
+def serialize_eels_withdrawal_for_block(withdrawal):
+    return {
+        "index": int(withdrawal.index),
+        "validatorIndex": int(withdrawal.validator_index),
+        "address": withdrawal.address,
+        "amount": int(withdrawal.amount),
+    }
 
 
 def serialize_block(

--- a/eth_tester/backends/eels/serializers.py
+++ b/eth_tester/backends/eels/serializers.py
@@ -2,6 +2,7 @@ import time
 from typing import (
     Any,
     Dict,
+    Sequence,
     Union,
 )
 
@@ -12,9 +13,11 @@ from .utils import (
 if eels_is_available():
     from ethereum.cancun.blocks import (
         Block,
+        Log,
     )
 else:
     Block = None
+    Log = None
 
 from eth_tester.constants import (
     BLANK_ROOT_HASH,
@@ -22,7 +25,7 @@ from eth_tester.constants import (
     ZERO_HASH32,
 )
 from eth_tester.utils.casing import (
-    lower_camel_case_to_snake_case,
+    dict_keys_to_lower_camel_case,
 )
 from eth_tester.utils.transactions import (
     calculate_effective_gas_price,
@@ -31,15 +34,18 @@ from eth_tester.utils.transactions import (
 
 
 def _serialize_withdrawals_to_block(serialized_block, withdrawals):
+    txn_withdrawals = []
     for withdrawal in withdrawals:
-        serialized_block["withdrawals"].append(
+        txn_withdrawals.append(
             {
                 "index": int(withdrawal.index),
-                "validator_index": int(withdrawal.validator_index),
+                "validatorIndex": int(withdrawal.validator_index),
                 "address": withdrawal.address,
                 "amount": int(withdrawal.amount),
             }
         )
+
+    serialized_block["withdrawals"] = txn_withdrawals
     return serialized_block
 
 
@@ -126,12 +132,13 @@ def serialize_block(
             serialized_block, block.withdrawals
         )
 
-    return serialized_block
+    return dict_keys_to_lower_camel_case(serialized_block)
 
 
 def _serialize_txs_to_block(
     backend_instance, serialized_block, tx_list, full_transactions
 ):
+    txns = []
     for i, tx in enumerate(tx_list):
         if full_transactions:
             json_tx = serialize_eels_transaction_for_block(
@@ -141,10 +148,11 @@ def _serialize_txs_to_block(
                 serialized_block["number"],
                 serialized_block["hash"],
             )
-            serialized_block["transactions"].append(json_tx)
+            txns.append(json_tx)
         else:
-            serialized_block["transactions"].append(backend_instance._get_tx_hash(tx))
+            txns.append(backend_instance._get_tx_hash(tx))
 
+    serialized_block["transactions"] = txns
     return serialized_block
 
 
@@ -209,7 +217,7 @@ def serialize_eels_transaction_for_block(
     elif isinstance(tx, backend_instance._transactions_module.BlobTransaction):
         json_tx["type"] = "0x03"
 
-    return json_tx
+    return dict_keys_to_lower_camel_case(json_tx)
 
 
 def serialize_transaction(tx, pending_block: Dict[str, Any] = None):
@@ -218,14 +226,11 @@ def serialize_transaction(tx, pending_block: Dict[str, Any] = None):
         tx["block_number"] = int(pending_block["header"]["number"])
         tx["transaction_index"] = len(pending_block["transactions"]) - 1
 
-    serialized = {
-        lower_camel_case_to_snake_case(key): value for key, value in tx.items()
-    }
-
+    serialized = tx.copy()
     if "gas_limit" in serialized and "gas" not in serialized:
         serialized["gas"] = serialized.pop("gas_limit")
 
-    return serialized
+    return dict_keys_to_lower_camel_case(serialized)
 
 
 def serialize_pending_receipt(
@@ -235,7 +240,7 @@ def serialize_pending_receipt(
     index,
     cumulative_gas_used,
     contract_address=None,
-):
+) -> Dict[str, Any]:
     tx_hash = backend_instance._get_tx_hash(tx)
     tx_gas_consumed = int(process_transaction_return[0])
 
@@ -269,18 +274,21 @@ def serialize_pending_receipt(
         "status": 0 if errors else 1,
         "type": extract_transaction_type(tx),
     }
-    return serialized
+
+    return dict_keys_to_lower_camel_case(serialized)
 
 
-def serialize_pending_logs(eels_logs):
+def serialize_pending_logs(eels_logs: Sequence["Log"]) -> Sequence[Dict[str, Any]]:
     return [
-        {
-            "address": log.address,
-            "topics": log.topics,
-            "data": log.data,
-            "log_index": int(i),
-            "type": "pending",
-            # rest of the fields are added when block is finalized
-        }
+        dict_keys_to_lower_camel_case(
+            {
+                "address": log.address,
+                "topics": log.topics,
+                "data": log.data,
+                "log_index": int(i),
+                "type": "pending",
+                # rest of the fields are added when block is finalized
+            }
+        )
         for i, log in enumerate(eels_logs)
     ]

--- a/eth_tester/backends/pyevm/serializers.py
+++ b/eth_tester/backends/pyevm/serializers.py
@@ -1,7 +1,7 @@
+import rlp
 from eth_utils import (
     to_int,
 )
-import rlp
 from toolz import (
     merge,
 )
@@ -66,21 +66,21 @@ def serialize_block(block, full_transaction, is_pending):
     block_info = {
         "number": block.header.block_number,
         "hash": block.header.hash,
-        "parent_hash": block.header.parent_hash,
+        "parentHash": block.header.parent_hash,
         "nonce": block.header.nonce,
-        "sha3_uncles": block.header.uncles_hash,
-        "logs_bloom": block.header.bloom,
-        "transactions_root": block.header.transaction_root,
-        "receipts_root": block.header.receipt_root,
-        "state_root": block.header.state_root,
+        "sha3Uncles": block.header.uncles_hash,
+        "logsBloom": block.header.bloom,
+        "transactionsRoot": block.header.transaction_root,
+        "receiptsRoot": block.header.receipt_root,
+        "stateRoot": block.header.state_root,
         "coinbase": block.header.coinbase,
         "difficulty": block.header.difficulty,
-        "total_difficulty": block.header.difficulty,  # TODO: actual total difficulty
-        "mix_hash": block.header.mix_hash,
+        "totalDifficulty": block.header.difficulty,  # TODO: actual total difficulty
+        "mixHash": block.header.mix_hash,
         "size": len(rlp.encode(block)),
-        "extra_data": pad32(block.header.extra_data),
-        "gas_limit": block.header.gas_limit,
-        "gas_used": block.header.gas_used,
+        "extraData": pad32(block.header.extra_data),
+        "gasLimit": block.header.gas_limit,
+        "gasUsed": block.header.gas_used,
         "timestamp": block.header.timestamp,
         "transactions": transactions,
         "uncles": [uncle.hash for uncle in block.uncles],
@@ -89,20 +89,20 @@ def serialize_block(block, full_transaction, is_pending):
     # london
     if is_london_block(block):
         base_fee = block.header.base_fee_per_gas
-        block_info.update({"base_fee_per_gas": base_fee})
+        block_info.update({"baseFeePerGas": base_fee})
 
     # shanghai
     if is_shanghai_block(block):
         block_info.update({"withdrawals": serialize_block_withdrawals(block)})
-        block_info.update({"withdrawals_root": block.header.withdrawals_root})
+        block_info.update({"withdrawalsRoot": block.header.withdrawals_root})
 
     # cancun
     if is_cancun_block(block):
         block_info.update(
-            {"parent_beacon_block_root": block.header.parent_beacon_block_root}
+            {"parentBeaconBlockRoot": block.header.parent_beacon_block_root}
         )
-        block_info.update({"blob_gas_used": block.header.blob_gas_used})
-        block_info.update({"excess_blob_gas": block.header.excess_blob_gas})
+        block_info.update({"blobGasUsed": block.header.blob_gas_used})
+        block_info.update({"excessBlobGas": block.header.excess_blob_gas})
 
     return block_info
 
@@ -118,9 +118,9 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
         "type": txn_type,
         "hash": transaction.hash,
         "nonce": transaction.nonce,
-        "block_hash": None if is_pending else block.hash,
-        "block_number": None if is_pending else block.number,
-        "transaction_index": None if is_pending else transaction_index,
+        "blockHash": None if is_pending else block.hash,
+        "blockNumber": None if is_pending else block.number,
+        "transactionIndex": None if is_pending else transaction_index,
         "from": transaction.sender,
         "to": transaction.to,
         "value": transaction.value,
@@ -131,7 +131,7 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
     type_specific_params = {}
     if txn_type in (LEGACY_TX_TYPE, ACCESS_LIST_TX_TYPE):
         type_specific_params = {
-            "gas_price": transaction.gas_price,
+            "gasPrice": transaction.gas_price,
         }
 
     if txn_type > LEGACY_TX_TYPE:
@@ -139,8 +139,8 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
         type_specific_params = merge(
             type_specific_params,
             {
-                "chain_id": transaction.chain_id,
-                "access_list": transaction.access_list or (),
+                "chainId": transaction.chain_id,
+                "accessList": transaction.access_list or (),
             },
         )
 
@@ -149,12 +149,12 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
             type_specific_params = merge(
                 type_specific_params,
                 {
-                    "max_fee_per_gas": transaction.max_fee_per_gas,
-                    "max_priority_fee_per_gas": transaction.max_priority_fee_per_gas,
+                    "maxFeePerGas": transaction.max_fee_per_gas,
+                    "maxPriorityFeePerGas": transaction.max_priority_fee_per_gas,
                     # TODO: Sometime in 2022 the inclusion of gas_price may be removed
                     #  from dynamic fee transactions and we can get rid of this
                     #  behavior. https://github.com/ethereum/execution-specs/pull/251
-                    "gas_price": (
+                    "gasPrice": (
                         transaction.max_fee_per_gas
                         if is_pending
                         else calculate_effective_gas_price(transaction, block.header)
@@ -166,8 +166,8 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
                 type_specific_params = merge(
                     type_specific_params,
                     {
-                        "max_fee_per_blob_gas": transaction.max_fee_per_blob_gas,
-                        "blob_versioned_hashes": transaction.blob_versioned_hashes,
+                        "maxFeePerBlobGas": transaction.max_fee_per_blob_gas,
+                        "blobVersionedHashes": transaction.blob_versioned_hashes,
                     },
                 )
     else:
@@ -187,7 +187,7 @@ def serialize_transaction(block, transaction, transaction_index, is_pending):
     if txn_type > LEGACY_TX_TYPE:
         # If anything other than a legacy tx, `y_parity` is the correct signature field.
         # Clients commonly return both `v` and `y_parity` for these transactions.
-        signed_tx_params["y_parity"] = signed_tx_params["v"]
+        signed_tx_params["yParity"] = signed_tx_params["v"]
 
     return merge(common_transaction_params, type_specific_params, signed_tx_params)
 
@@ -229,32 +229,32 @@ def serialize_transaction_receipt(
         origin_gas = receipts[transaction_index - 1].gas_used
 
     receipt_fields = {
-        "block_hash": None if is_pending else block.hash,
-        "block_number": None if is_pending else block.number,
-        "contract_address": contract_addr,
-        "cumulative_gas_used": receipt.gas_used,
-        "effective_gas_price": calculate_effective_gas_price(transaction, block.header),
+        "blockHash": None if is_pending else block.hash,
+        "blockNumber": None if is_pending else block.number,
+        "contractAddress": contract_addr,
+        "cumulativeGasUsed": receipt.gas_used,
+        "effectiveGasPrice": calculate_effective_gas_price(transaction, block.header),
         "from": transaction.sender,
-        "gas_used": receipt.gas_used - origin_gas,
+        "gasUsed": receipt.gas_used - origin_gas,
         "logs": [
             serialize_log(
                 block, transaction, transaction_index, log, log_index, is_pending
             )
             for log_index, log in enumerate(receipt.logs)
         ],
-        "state_root": state_root,
+        "stateRoot": state_root,
         "status": to_int(state_root),
         "to": transaction.to,
-        "transaction_hash": transaction.hash,
-        "transaction_index": None if is_pending else transaction_index,
+        "transactionHash": transaction.hash,
+        "transactionIndex": None if is_pending else transaction_index,
         "type": _txn_type,
     }
 
     if _txn_type == BLOB_TX_TYPE:
         # blob transaction
         blob_gas_used = GAS_PER_BLOB * len(transaction.blob_versioned_hashes)
-        receipt_fields["blob_gas_used"] = blob_gas_used
-        receipt_fields["blob_gas_price"] = vm.state.blob_base_fee * blob_gas_used
+        receipt_fields["blobGasUsed"] = blob_gas_used
+        receipt_fields["blobGasPrice"] = vm.state.blob_base_fee * blob_gas_used
 
     return receipt_fields
 
@@ -262,11 +262,11 @@ def serialize_transaction_receipt(
 def serialize_log(block, transaction, transaction_index, log, log_index, is_pending):
     return {
         "type": "pending" if is_pending else "mined",
-        "log_index": log_index,
-        "transaction_index": None if is_pending else transaction_index,
-        "transaction_hash": transaction.hash,
-        "block_hash": None if is_pending else block.hash,
-        "block_number": None if is_pending else block.number,
+        "logIndex": log_index,
+        "transactionIndex": None if is_pending else transaction_index,
+        "transactionHash": transaction.hash,
+        "blockHash": None if is_pending else block.hash,
+        "blockNumber": None if is_pending else block.number,
         "address": log.address,
         "data": log.data,
         "topics": [int_to_32byte_big_endian(topic) for topic in log.topics],
@@ -285,7 +285,7 @@ def serialize_block_withdrawals(block):
     return [
         {
             "index": withdrawal.index,
-            "validator_index": withdrawal.validator_index,
+            "validatorIndex": withdrawal.validator_index,
             "address": withdrawal.address,
             "amount": withdrawal.amount,
         }

--- a/eth_tester/backends/pyevm/serializers.py
+++ b/eth_tester/backends/pyevm/serializers.py
@@ -1,7 +1,7 @@
-import rlp
 from eth_utils import (
     to_int,
 )
+import rlp
 from toolz import (
     merge,
 )

--- a/eth_tester/backends/pyevm/utils.py
+++ b/eth_tester/backends/pyevm/utils.py
@@ -54,7 +54,7 @@ def is_london_block(block: Union[Dict[str, Any], BlockAPI]) -> bool:
         except AttributeError:
             return False
 
-    elif isinstance(block, dict) and "base_fee_per_gas" in block:
+    elif isinstance(block, dict) and "baseFeePerGas" in block:
         return True
 
     return False
@@ -68,7 +68,7 @@ def is_shanghai_block(block: Union[Dict[str, Any], BlockAPI]) -> bool:
             return block.header.withdrawals_root is not None
         except AttributeError:
             return False
-    elif isinstance(block, dict) and "withdrawals_root" in block:
+    elif isinstance(block, dict) and "withdrawalsRoot" in block:
         return True
 
     return False
@@ -86,9 +86,9 @@ def is_cancun_block(block: Union[Dict[str, Any], BlockAPI]) -> bool:
     elif isinstance(block, dict) and all(
         cancun_field in block
         for cancun_field in (
-            "parent_beacon_block_root",
-            "blob_gas_used",
-            "excess_blob_gas",
+            "parentBeaconBlockRoot",
+            "blobGasUsed",
+            "excessBlobGas",
         )
     ):
         return True

--- a/eth_tester/normalization/outbound.py
+++ b/eth_tester/normalization/outbound.py
@@ -47,7 +47,7 @@ def _normalize_outbound_access_list(access_list):
         [
             {
                 "address": to_checksum_address(entry[0]),
-                "storage_keys": tuple(
+                "storageKeys": tuple(
                     [encode_hex(int_to_32byte_big_endian(k)) for k in entry[1]]
                 ),
             }
@@ -58,39 +58,39 @@ def _normalize_outbound_access_list(access_list):
 
 TRANSACTION_NORMALIZERS = {
     "type": to_hex_if_integer,
-    "blob_versioned_hashes": partial(
+    "blobVersionedHashes": partial(
         normalize_array,
         normalizer=partial(
             normalize_if, conditional_fn=is_bytes, normalizer=encode_hex
         ),
     ),
-    "chain_id": identity,
+    "chainId": identity,
     "hash": encode_hex,
     "nonce": identity,
-    "block_hash": partial(normalize_if, conditional_fn=is_bytes, normalizer=encode_hex),
-    "block_number": identity,
-    "transaction_index": identity,
+    "blockHash": partial(normalize_if, conditional_fn=is_bytes, normalizer=encode_hex),
+    "blockNumber": identity,
+    "transactionIndex": identity,
     "from": to_checksum_address,
     "to": to_empty_or_checksum_address,
     "value": identity,
     "gas": identity,
-    "gas_price": identity,
-    "max_fee_per_blob_gas": identity,
-    "max_fee_per_gas": identity,
-    "max_priority_fee_per_gas": identity,
+    "gasPrice": identity,
+    "maxFeePerBlobGas": identity,
+    "maxFeePerGas": identity,
+    "maxPriorityFeePerGas": identity,
     "data": encode_hex,
-    "access_list": _normalize_outbound_access_list,
+    "accessList": _normalize_outbound_access_list,
     "r": identity,
     "s": identity,
     "v": identity,
-    "y_parity": identity,
+    "yParity": identity,
 }
 normalize_transaction = partial(normalize_dict, normalizers=TRANSACTION_NORMALIZERS)
 
 
 WITHDRAWAL_NORMALIZERS = {
     "index": identity,
-    "validator_index": identity,
+    "validatorIndex": identity,
     "address": to_checksum_address,
     "amount": identity,
 }
@@ -120,22 +120,22 @@ def _remove_fork_specific_fields_if_none(block):
 BLOCK_NORMALIZERS = {
     "number": identity,
     "hash": encode_hex,
-    "parent_hash": encode_hex,
+    "parentHash": encode_hex,
     "nonce": encode_hex,
-    "base_fee_per_gas": identity,
-    "sha3_uncles": encode_hex,
-    "logs_bloom": identity,
-    "transactions_root": encode_hex,
-    "receipts_root": encode_hex,
-    "state_root": encode_hex,
+    "baseFeePerGas": identity,
+    "sha3Uncles": encode_hex,
+    "logsBloom": identity,
+    "transactionsRoot": encode_hex,
+    "receiptsRoot": encode_hex,
+    "stateRoot": encode_hex,
     "coinbase": to_checksum_address,
     "difficulty": identity,
-    "mix_hash": encode_hex,
-    "total_difficulty": identity,
+    "mixHash": encode_hex,
+    "totalDifficulty": identity,
     "size": identity,
-    "extra_data": encode_hex,
-    "gas_limit": identity,
-    "gas_used": identity,
+    "extraData": encode_hex,
+    "gasLimit": identity,
+    "gasUsed": identity,
     "timestamp": identity,
     "transactions": compose(
         partial(
@@ -151,10 +151,10 @@ BLOCK_NORMALIZERS = {
     ),
     "uncles": partial(normalize_array, normalizer=encode_hex),
     "withdrawals": partial(normalize_array, normalizer=normalize_withdrawal),
-    "withdrawals_root": encode_hex,
-    "parent_beacon_block_root": encode_hex,
-    "blob_gas_used": identity,
-    "excess_blob_gas": identity,
+    "withdrawalsRoot": encode_hex,
+    "parentBeaconBlockRoot": encode_hex,
+    "blobGasUsed": identity,
+    "excessBlobGas": identity,
 }
 normalize_block = compose(
     partial(normalize_dict, normalizers=BLOCK_NORMALIZERS),
@@ -164,19 +164,19 @@ normalize_block = compose(
 
 LOG_ENTRY_NORMALIZERS = {
     "type": identity,
-    "log_index": identity,
-    "transaction_index": partial(
+    "logIndex": identity,
+    "transactionIndex": partial(
         normalize_if,
         conditional_fn=is_bytes,
         normalizer=encode_hex,
     ),
-    "transaction_hash": encode_hex,
-    "block_hash": partial(
+    "transactionHash": encode_hex,
+    "blockHash": partial(
         normalize_if,
         conditional_fn=is_bytes,
         normalizer=encode_hex,
     ),
-    "block_number": identity,
+    "blockNumber": identity,
     "address": to_checksum_address,
     "data": encode_hex,
     "topics": partial(normalize_array, normalizer=encode_hex),
@@ -186,39 +186,39 @@ normalize_log_entry = partial(normalize_dict, normalizers=LOG_ENTRY_NORMALIZERS)
 
 def _normalize_contract_address(receipt):
     if receipt["status"] == 0:
-        return assoc(receipt, "contract_address", None)
-    elif is_address(receipt["contract_address"]):
+        return assoc(receipt, "contractAddress", None)
+    elif is_address(receipt["contractAddress"]):
         return assoc(
             receipt,
-            "contract_address",
-            to_checksum_address(receipt["contract_address"]),
+            "contractAddress",
+            to_checksum_address(receipt["contractAddress"]),
         )
     else:
         return receipt
 
 
 RECEIPT_NORMALIZERS = {
-    "transaction_hash": encode_hex,
-    "transaction_index": identity,
-    "block_number": identity,
-    "block_hash": partial(
+    "transactionHash": encode_hex,
+    "transactionIndex": identity,
+    "blockNumber": identity,
+    "blockHash": partial(
         normalize_if,
         conditional_fn=is_bytes,
         normalizer=encode_hex,
     ),
-    "cumulative_gas_used": identity,
-    "effective_gas_price": identity,
+    "cumulativeGasUsed": identity,
+    "effectiveGasPrice": identity,
     "from": to_checksum_address,
-    "gas_used": identity,
-    "contract_address": identity,  # special case, see ``_normalize_contract_address()``
+    "gasUsed": identity,
+    "contractAddress": identity,  # special case, see ``_normalize_contract_address()``
     "logs": partial(normalize_array, normalizer=normalize_log_entry),
-    "state_root": identity,
+    "stateRoot": identity,
     "status": identity,
     "to": to_empty_or_checksum_address,
     "type": to_hex_if_integer,
-    "base_fee_per_gas": identity,
-    "blob_gas_used": identity,
-    "blob_gas_price": identity,
+    "baseFeePerGas": identity,
+    "blobGasUsed": identity,
+    "blobGasPrice": identity,
 }
 normalize_receipt = compose(
     partial(normalize_dict, normalizers=RECEIPT_NORMALIZERS),

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -1,5 +1,5 @@
 import pytest
-
+import rlp
 from eth_keys import (
     keys,
 )
@@ -17,7 +17,6 @@ from eth_utils.toolz import (
     dissoc,
     merge,
 )
-import rlp
 
 from eth_tester.constants import (
     BURN_ADDRESS,
@@ -78,21 +77,21 @@ CONTRACT_TRANSACTION_MISSING_TO = dissoc(CONTRACT_TRANSACTION_EMPTY_TO, "to")
 BLOCK_KEYS = {
     "number",
     "hash",
-    "parent_hash",
+    "parentHash",
     "nonce",
-    "sha3_uncles",
-    "logs_bloom",
-    "transactions_root",
-    "receipts_root",
-    "state_root",
+    "sha3Uncles",
+    "logsBloom",
+    "transactionsRoot",
+    "receiptsRoot",
+    "stateRoot",
     "coinbase",
     "difficulty",
-    "mix_hash",
-    "total_difficulty",
+    "mixHash",
+    "totalDifficulty",
     "size",
-    "extra_data",
-    "gas_limit",
-    "gas_used",
+    "extraData",
+    "gasLimit",
+    "gasUsed",
     "timestamp",
     "transactions",
     "uncles",

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -1,5 +1,5 @@
 import pytest
-import rlp
+
 from eth_keys import (
     keys,
 )
@@ -17,6 +17,7 @@ from eth_utils.toolz import (
     dissoc,
     merge,
 )
+import rlp
 
 from eth_tester.constants import (
     BURN_ADDRESS,

--- a/eth_tester/utils/casing.py
+++ b/eth_tester/utils/casing.py
@@ -1,3 +1,9 @@
+from typing import (
+    Any,
+    Dict,
+)
+
+
 def snake_case_to_lower_camel_case(snake_case_string: str) -> str:
     return "".join(
         word.capitalize() if i > 0 else word
@@ -10,3 +16,11 @@ def lower_camel_case_to_snake_case(lower_camel_case_string: str) -> str:
         f"_{char.lower()}" if char.isupper() else char
         for char in lower_camel_case_string
     )
+
+
+def dict_keys_to_lower_camel_case(d: Dict[str, Any]) -> Dict[str, Any]:
+    serialized = {}
+    for key in d:
+        serialized[snake_case_to_lower_camel_case(key)] = d[key]
+
+    return serialized

--- a/eth_tester/validation/outbound.py
+++ b/eth_tester/validation/outbound.py
@@ -78,11 +78,11 @@ def validate_log_entry_type(value):
 
 LOG_ENTRY_VALIDATORS = {
     "type": validate_log_entry_type,
-    "log_index": validate_positive_integer,
-    "transaction_index": if_not_null(validate_positive_integer),
-    "transaction_hash": validate_32_byte_string,
-    "block_hash": if_not_null(validate_32_byte_string),
-    "block_number": if_not_null(validate_positive_integer),
+    "logIndex": validate_positive_integer,
+    "transactionIndex": if_not_null(validate_positive_integer),
+    "transactionHash": validate_32_byte_string,
+    "blockHash": if_not_null(validate_32_byte_string),
+    "blockNumber": if_not_null(validate_positive_integer),
     "address": validate_canonical_address,
     "data": validate_bytes,
     "topics": partial(validate_array, validator=validate_32_byte_string),
@@ -135,14 +135,14 @@ LEGACY_TRANSACTION_VALIDATORS = {
     "type": validate_transaction_type,
     "hash": validate_32_byte_string,
     "nonce": validate_uint256,
-    "block_hash": if_not_null(validate_32_byte_string),
-    "block_number": if_not_null(validate_positive_integer),
-    "transaction_index": if_not_null(validate_positive_integer),
+    "blockHash": if_not_null(validate_32_byte_string),
+    "blockNumber": if_not_null(validate_positive_integer),
+    "transactionIndex": if_not_null(validate_positive_integer),
     "from": validate_canonical_address,
     "to": if_not_create_address(validate_canonical_address),
     "value": validate_uint256,
     "gas": validate_uint256,
-    "gas_price": validate_uint256,
+    "gasPrice": validate_uint256,
     "data": validate_bytes,
     "v": validate_signature_v,
     "r": validate_uint256,
@@ -157,21 +157,20 @@ ACCESS_LIST_TRANSACTION_VALIDATORS = merge(
     LEGACY_TRANSACTION_VALIDATORS,
     {
         "v": validate_y_parity,
-        "y_parity": validate_y_parity,
-        "chain_id": validate_uint256,
-        "access_list": _validate_outbound_access_list,
+        "yParity": validate_y_parity,
+        "chainId": validate_uint256,
+        "accessList": _validate_outbound_access_list,
     },
 )
 validate_access_list_transaction = partial(
     validate_dict, key_validators=ACCESS_LIST_TRANSACTION_VALIDATORS
 )
 
-
 DYNAMIC_FEE_TRANSACTION_VALIDATORS = merge(
     ACCESS_LIST_TRANSACTION_VALIDATORS,
     {
-        "max_fee_per_gas": validate_uint256,
-        "max_priority_fee_per_gas": validate_uint256,
+        "maxFeePerGas": validate_uint256,
+        "maxPriorityFeePerGas": validate_uint256,
     },
 )
 validate_dynamic_fee_transaction = partial(
@@ -181,8 +180,8 @@ validate_dynamic_fee_transaction = partial(
 BLOB_TRANSACTION_VALIDATORS = merge(
     DYNAMIC_FEE_TRANSACTION_VALIDATORS,
     {
-        "max_fee_per_blob_gas": validate_uint256,
-        "blob_versioned_hashes": partial(
+        "maxFeePerBlobGas": validate_uint256,
+        "blobVersionedHashes": partial(
             validate_array,
             validator=validate_32_byte_string,
         ),
@@ -205,7 +204,7 @@ validate_transaction = partial(
 
 WITHDRAWAL_VALIDATORS = {
     "index": validate_uint64,
-    "validator_index": validate_uint64,
+    "validatorIndex": validate_uint64,
     "address": validate_canonical_address,
     "amount": validate_uint64,
 }
@@ -219,17 +218,17 @@ def validate_status(value):
 
 
 RECEIPT_VALIDATORS = {
-    "transaction_hash": validate_32_byte_string,
-    "transaction_index": if_not_null(validate_positive_integer),
-    "block_number": if_not_null(validate_positive_integer),
-    "block_hash": if_not_null(validate_32_byte_string),
-    "cumulative_gas_used": validate_positive_integer,
-    "effective_gas_price": if_not_null(validate_positive_integer),
+    "transactionHash": validate_32_byte_string,
+    "transactionIndex": if_not_null(validate_positive_integer),
+    "blockNumber": if_not_null(validate_positive_integer),
+    "blockHash": if_not_null(validate_32_byte_string),
+    "cumulativeGasUsed": validate_positive_integer,
+    "effectiveGasPrice": if_not_null(validate_positive_integer),
     "from": validate_canonical_address,
-    "gas_used": validate_positive_integer,
-    "contract_address": if_not_null(validate_canonical_address),
+    "gasUsed": validate_positive_integer,
+    "contractAddress": if_not_null(validate_canonical_address),
     "logs": partial(validate_array, validator=validate_log_entry),
-    "state_root": validate_bytes,
+    "stateRoot": validate_bytes,
     "status": validate_status,
     "to": if_not_create_address(validate_canonical_address),
     "type": validate_transaction_type,
@@ -237,10 +236,12 @@ RECEIPT_VALIDATORS = {
 CANCUN_RECEIPT_VALIDATORS = merge(
     RECEIPT_VALIDATORS,
     {
-        "blob_gas_used": validate_positive_integer,
-        "blob_gas_price": validate_positive_integer,
+        "blobGasUsed": validate_positive_integer,
+        "blobGasPrice": validate_positive_integer,
     },
 )
+
+
 validate_receipt = partial(
     validate_any,
     validators=(
@@ -253,21 +254,21 @@ validate_receipt = partial(
 BLOCK_VALIDATORS = {
     "number": validate_positive_integer,
     "hash": validate_block_hash,
-    "parent_hash": validate_block_hash,
+    "parentHash": validate_block_hash,
     "nonce": validate_nonce,
-    "sha3_uncles": validate_32_byte_string,
-    "logs_bloom": validate_logs_bloom,
-    "transactions_root": validate_32_byte_string,
-    "receipts_root": validate_32_byte_string,
-    "state_root": validate_32_byte_string,
+    "sha3Uncles": validate_32_byte_string,
+    "logsBloom": validate_logs_bloom,
+    "transactionsRoot": validate_32_byte_string,
+    "receiptsRoot": validate_32_byte_string,
+    "stateRoot": validate_32_byte_string,
     "coinbase": validate_canonical_address,
     "difficulty": validate_positive_integer,
-    "mix_hash": validate_32_byte_string,
-    "total_difficulty": validate_positive_integer,
+    "mixHash": validate_32_byte_string,
+    "totalDifficulty": validate_positive_integer,
     "size": validate_positive_integer,
-    "extra_data": validate_32_byte_string,
-    "gas_limit": validate_positive_integer,
-    "gas_used": validate_positive_integer,
+    "extraData": validate_32_byte_string,
+    "gasLimit": validate_positive_integer,
+    "gasUsed": validate_positive_integer,
     "timestamp": validate_positive_integer,
     "transactions": partial(
         validate_any,
@@ -282,14 +283,14 @@ BLOCK_VALIDATORS = {
     "uncles": partial(validate_array, validator=validate_32_byte_string),
     # fork-specific fields, validated separately in `_validate_fork_specific_fields()`
     # London fork:
-    "base_fee_per_gas": identity,
+    "baseFeePerGas": identity,
     # Shanghai fork:
     "withdrawals": identity,
-    "withdrawals_root": identity,
+    "withdrawalsRoot": identity,
     # Cancun fork:
-    "parent_beacon_block_root": identity,
-    "blob_gas_used": identity,
-    "excess_blob_gas": identity,
+    "parentBeaconBlockRoot": identity,
+    "blobGasUsed": identity,
+    "excessBlobGas": identity,
 }
 
 
@@ -300,25 +301,25 @@ def _validate_fork_specific_fields(block):
     value to `None` during validation and pop it back out during normalization.
     """
     if is_london_block(block):
-        validate_positive_integer(block["base_fee_per_gas"])
+        validate_positive_integer(block["baseFeePerGas"])
     else:
-        block["base_fee_per_gas"] = None
+        block["baseFeePerGas"] = None
 
     if is_shanghai_block(block):
         partial(validate_array, validator=validate_withdrawal)(block["withdrawals"])
-        validate_32_byte_string(block["withdrawals_root"])
+        validate_32_byte_string(block["withdrawalsRoot"])
     else:
         block["withdrawals"] = None
-        block["withdrawals_root"] = None
+        block["withdrawalsRoot"] = None
 
     if is_cancun_block(block):
-        validate_32_byte_string(block["parent_beacon_block_root"])
-        validate_positive_integer(block["blob_gas_used"])
-        validate_positive_integer(block["excess_blob_gas"])
+        validate_32_byte_string(block["parentBeaconBlockRoot"])
+        validate_positive_integer(block["blobGasUsed"])
+        validate_positive_integer(block["excessBlobGas"])
     else:
-        block["parent_beacon_block_root"] = None
-        block["blob_gas_used"] = None
-        block["excess_blob_gas"] = None
+        block["parentBeaconBlockRoot"] = None
+        block["blobGasUsed"] = None
+        block["excessBlobGas"] = None
 
     return block
 

--- a/newsfragments/331.breaking.rst
+++ b/newsfragments/331.breaking.rst
@@ -1,0 +1,1 @@
+EELS and py-evm backends now convert dictionary keys from snake_case to camelCase. Outbound normalizers and validators have been updated to reflect this change. This is a breaking change that affects response payloads. The change is necessary to ensure compatibility with the EELS spec and to maintain consistency across clients.

--- a/newsfragments/331.internal.rst
+++ b/newsfragments/331.internal.rst
@@ -1,0 +1,3 @@
+Tests have been added for backend serializers in py-evm and EELS. Additional validation and normalization tests have been implemented. Refactored tests with helper functions and better parametrization.
+
+Backend EELS tests run as part of separate CI jobs for Python 3.10+. The ethereum-execution package is now pinned at ``1.17.0rc6.dev1``.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extras_require = {
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],
     "eels": [
-        "ethereum-execution",
+        "ethereum-execution==1.17.0rc6.dev1",
     ],
 }
 

--- a/tests/backends/eels/conftest.py
+++ b/tests/backends/eels/conftest.py
@@ -1,0 +1,319 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import pytest
+from eth.abc import (
+    Hash32,
+)
+from ethereum.cancun.blocks import (
+    Block,
+    Header,
+    Log,
+    Withdrawal,
+)
+from ethereum.cancun.fork_types import (
+    Bloom,
+    Root,
+)
+from ethereum.cancun.transactions import (
+    AccessListTransaction,
+    BlobTransaction,
+    FeeMarketTransaction,
+    LegacyTransaction,
+)
+from ethereum_types.bytes import (
+    Bytes,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+)
+from ethereum_types.numeric import (
+    U64,
+    U256,
+    Uint,
+)
+
+from eth_tester.constants import (
+    ZERO_ADDRESS,
+    ZERO_HASH32,
+)
+
+
+@pytest.fixture
+def transaction() -> LegacyTransaction:
+    return LegacyTransaction(
+        nonce=U256(0),
+        gas_price=Uint(0),
+        gas=Uint(0),
+        to=Bytes20(ZERO_ADDRESS),
+        value=U256(0),
+        data=b"",
+        v=U256(38),
+        r=U256(1),
+        s=U256(2),
+    )
+
+
+@pytest.fixture
+def transaction_dict() -> Dict[str, Any]:
+    return {
+        "nonce": 0,
+        "gas_price": 0,
+        "gas": 0,
+        "to": b"\x00" * 20,
+        "value": 0,
+        "data": b"",
+        "v": 38,
+        "r": 1,
+        "s": 2,
+    }
+
+
+@pytest.fixture
+def block_header(request: pytest.FixtureRequest) -> Header:
+    return Header(
+        parent_hash=Bytes32(b"\x00" * 32),
+        ommers_hash=Bytes32(b"\x00" * 32),
+        coinbase=Bytes20(ZERO_ADDRESS),
+        state_root=Root(ZERO_HASH32),
+        transactions_root=Root(ZERO_HASH32),
+        receipt_root=Root(ZERO_HASH32),
+        bloom=Bloom(b"\x00" * 256),
+        difficulty=Uint(0),
+        number=Uint(0),
+        gas_limit=Uint(0),
+        gas_used=Uint(0),
+        timestamp=U256(0),
+        extra_data=Bytes(b""),
+        prev_randao=Bytes32(b"\x00" * 32),
+        nonce=Bytes8(b"\x00" * 8),
+        base_fee_per_gas=Uint(0),
+        withdrawals_root=Root(ZERO_HASH32),
+        blob_gas_used=U64(0),
+        excess_blob_gas=U64(0),
+        parent_beacon_block_root=Root(ZERO_HASH32),
+    )
+
+
+@pytest.fixture(params=[True, False], ids=["pending", "finalized"])
+def block(
+    request: pytest.FixtureRequest,
+    pending_block: Dict[str, Any],
+    finalized_block: Block,
+) -> Union[Block, Dict[str, Any]]:
+    is_pending = request.param
+    if is_pending:
+        return pending_block
+    else:
+        return finalized_block
+
+
+@pytest.fixture(
+    params=[
+        "no_pending_block",
+        "empty_pending_block",
+        "pending_block",
+    ],
+)
+def parameterized_pending_block(
+    request: pytest.FixtureRequest,
+    pending_block_header: Dict[str, Any],
+    block_transactions: Sequence[Union[Bytes, LegacyTransaction]],
+    withdrawals: Tuple[Withdrawal, ...],
+) -> Union[None, Dict[str, Any]]:
+    if request.param == "pending_block":
+        return {
+            "header": pending_block_header,
+            "transactions": block_transactions,
+            "ommers": (),
+            "withdrawals": withdrawals,
+        }
+    elif request.param == "empty":
+        return {}
+    return None
+
+
+@pytest.fixture
+def pending_block(
+    pending_block_header: Dict[str, Any],
+    block_transactions: Sequence[Union[Bytes, LegacyTransaction]],
+    withdrawals: Tuple[Withdrawal, ...],
+) -> Dict[str, Any]:
+    return {
+        "header": pending_block_header,
+        "transactions": block_transactions,
+        "ommers": (),
+        "withdrawals": withdrawals,
+    }
+
+
+@pytest.fixture
+def finalized_block(
+    block_header: Header,
+    block_transactions: Tuple[Union[Bytes, LegacyTransaction]],
+    withdrawals: Tuple[Withdrawal],
+) -> Block:
+    return Block(
+        header=block_header,
+        transactions=block_transactions,
+        ommers=(),
+        withdrawals=withdrawals,
+    )
+
+
+@pytest.fixture
+def pending_block_header() -> Dict[str, Any]:
+    return {
+        "parent_hash": b"\x00" * 32,
+        "ommers_hash": b"\x00" * 32,
+        "coinbase": b"\x00" * 20,
+        "state_root": ZERO_HASH32,
+        "transactions_root": ZERO_HASH32,
+        "receipt_root": ZERO_HASH32,
+        "bloom": b"\x00" * 256,
+        "difficulty": 0,
+        "number": 0,
+        "gas_limit": 0,
+        "gas_used": 0,
+        "timestamp": 0,
+        "extra_data": b"",
+        "prev_randao": b"\x00" * 32,
+        "nonce": b"\x00" * 8,
+        "base_fee_per_gas": 0,
+        "withdrawals_root": ZERO_HASH32,
+        "blob_gas_used": 0,
+        "excess_blob_gas": 0,
+    }
+
+
+@pytest.fixture(
+    params=(
+        "no_transactions",
+        "legacy_transactions",
+        "blob_transactions",
+        "fee_market_transactions",
+        "access_list_transactions",
+    )
+)
+def block_transactions(
+    request: pytest.FixtureRequest,
+) -> Sequence[
+    Union[
+        Bytes,
+        LegacyTransaction,
+        BlobTransaction,
+        FeeMarketTransaction,
+        AccessListTransaction,
+    ]
+]:
+    if request.param == "legacy_transactions":
+        return [
+            LegacyTransaction(
+                nonce=U256(0),
+                gas_price=Uint(0),
+                gas=Uint(0),
+                to=Bytes20(ZERO_ADDRESS),
+                value=U256(0),
+                data=b"",
+                v=U256(38),
+                r=U256(1),
+                s=U256(2),
+            ),
+        ]
+    elif request.param == "blob_transactions":
+        return [
+            BlobTransaction(
+                chain_id=U64(0),
+                nonce=U256(0),
+                max_priority_fee_per_gas=Uint(0),
+                max_fee_per_gas=Uint(0),
+                gas=Uint(0),
+                to=Bytes20(ZERO_ADDRESS),
+                value=U256(0),
+                data=b"",
+                access_list=(),
+                max_fee_per_blob_gas=U256(0),
+                blob_versioned_hashes=(Bytes32(b"\x00" * 32),),
+                y_parity=U256(0),
+                r=U256(1),
+                s=U256(2),
+            ),
+        ]
+    elif request.param == "fee_market_transactions":
+        return [
+            FeeMarketTransaction(
+                chain_id=U64(0),
+                nonce=U256(0),
+                max_priority_fee_per_gas=Uint(0),
+                max_fee_per_gas=Uint(0),
+                gas=Uint(0),
+                to=Bytes20(ZERO_ADDRESS),
+                value=U256(0),
+                data=b"",
+                access_list=(),
+                y_parity=U256(0),
+                r=U256(1),
+                s=U256(2),
+            ),
+        ]
+
+    return []
+
+
+@pytest.fixture(
+    params=(
+        (),
+        (
+            Withdrawal(
+                index=U64(0),
+                validator_index=U64(0),
+                address=Bytes20(ZERO_ADDRESS),
+                amount=U256(100),
+            ),
+        ),
+    ),
+    ids=["no_withdrawals", "one_withdrawal"],
+)
+def withdrawals(request: pytest.FixtureRequest) -> List[Withdrawal]:
+    return list(request.param)
+
+
+@pytest.fixture(
+    params=[
+        (1, (), 0),
+        (1, (), 1),
+        (
+            3,
+            (
+                Log(
+                    address=Bytes20(ZERO_ADDRESS),
+                    topics=(Bytes32(b"\x00" * 32), Bytes32(b"\x01" * 32)),
+                    data=b"\x02" * 32,
+                ),
+            ),
+            1,
+        ),
+    ],
+    ids=[
+        "empty_logs_with_no_error",
+        "empty_logs_with_error",
+        "one_log_with_error",
+    ],
+)
+def process_transaction_return(request: pytest.FixtureRequest) -> Tuple[int, Log, int]:
+    return tuple(request.param)
+
+
+@pytest.fixture
+def log() -> Log:
+    return Log(
+        address=Bytes20(ZERO_ADDRESS),
+        topics=(Bytes32(b"\x00" * 32), Bytes32(b"\x01" * 32)),
+        data=b"\x02" * 32,
+    )

--- a/tests/backends/eels/conftest.py
+++ b/tests/backends/eels/conftest.py
@@ -8,9 +8,6 @@ from typing import (
 )
 
 import pytest
-from eth.abc import (
-    Hash32,
-)
 from ethereum.cancun.blocks import (
     Block,
     Header,

--- a/tests/backends/eels/conftest.py
+++ b/tests/backends/eels/conftest.py
@@ -41,6 +41,86 @@ from eth_tester.constants import (
     ZERO_HASH32,
 )
 
+AnyTransaction = Union[
+    Bytes,
+    LegacyTransaction,
+    BlobTransaction,
+    FeeMarketTransaction,
+    AccessListTransaction,
+]
+
+
+@pytest.fixture()
+def block_keys() -> List[str]:
+    """
+    Returns a list of keys that are expected to be present in a block.
+    This is used to validate the serialization of blocks.
+    """
+    return [
+        "number",
+        "hash",
+        "parentHash",
+        "nonce",
+        "stateRoot",
+        "coinbase",
+        "transactionsRoot",
+        "receiptsRoot",
+        "logsBloom",
+        "gasLimit",
+        "gasUsed",
+        "timestamp",
+        "withdrawalsRoot",
+        "baseFeePerGas",
+        "blobGasUsed",
+        "excessBlobGas",
+        "transactions",
+        "uncles",
+        "withdrawals",
+        "sha3Uncles",
+        "difficulty",
+        "totalDifficulty",
+        "mixHash",
+        "size",
+        "extraData",
+    ]
+
+
+@pytest.fixture
+def finalized_block_keys(block_keys: List[str]) -> List[str]:
+    """
+    Returns a list of keys that are expected to be present in a finalized block.
+    This is used to validate the serialization of finalized blocks.
+    """
+    return block_keys + ["parentBeaconBlockRoot"]
+
+
+@pytest.fixture
+def block_transaction_keys() -> List[str]:
+    return [
+        "type",
+        "hash",
+        "nonce",
+        "blockHash",
+        "blockNumber",
+        "transactionIndex",
+        "gas",
+        "to",
+        "from",
+        "value",
+        "data",
+        "r",
+        "s",
+        "v",
+        "gasPrice",
+        "chainId",
+        "maxPriorityFeePerGas",
+        "maxFeePerGas",
+        "accessList",
+        "maxFeePerBlobGas",
+        "blobVersionedHashes",
+        "yParity",
+    ]
+
 
 @pytest.fixture
 def transaction() -> LegacyTransaction:
@@ -121,7 +201,7 @@ def block(
 def parameterized_pending_block(
     request: pytest.FixtureRequest,
     pending_block_header: Dict[str, Any],
-    block_transactions: Sequence[Union[Bytes, LegacyTransaction]],
+    block_transactions: Sequence[AnyTransaction],
     withdrawals: Tuple[Withdrawal, ...],
 ) -> Union[None, Dict[str, Any]]:
     if request.param == "pending_block":
@@ -139,7 +219,7 @@ def parameterized_pending_block(
 @pytest.fixture
 def pending_block(
     pending_block_header: Dict[str, Any],
-    block_transactions: Sequence[Union[Bytes, LegacyTransaction]],
+    block_transactions: Sequence[AnyTransaction],
     withdrawals: Tuple[Withdrawal, ...],
 ) -> Dict[str, Any]:
     return {
@@ -153,7 +233,7 @@ def pending_block(
 @pytest.fixture
 def finalized_block(
     block_header: Header,
-    block_transactions: Tuple[Union[Bytes, LegacyTransaction]],
+    block_transactions: Tuple[Union[Bytes, LegacyTransaction], ...],
     withdrawals: Tuple[Withdrawal],
 ) -> Block:
     return Block(
@@ -200,15 +280,7 @@ def pending_block_header() -> Dict[str, Any]:
 )
 def block_transactions(
     request: pytest.FixtureRequest,
-) -> Sequence[
-    Union[
-        Bytes,
-        LegacyTransaction,
-        BlobTransaction,
-        FeeMarketTransaction,
-        AccessListTransaction,
-    ]
-]:
+) -> Sequence[AnyTransaction]:
     if request.param == "legacy_transactions":
         return [
             LegacyTransaction(

--- a/tests/backends/eels/conftest.py
+++ b/tests/backends/eels/conftest.py
@@ -197,7 +197,7 @@ def pending_block_header() -> Dict[str, Any]:
         "no_transactions",
         "legacy_transactions",
         "blob_transactions",
-        "fee_market_transactions",
+        "dynamic_fee_transactions",
         "access_list_transactions",
     )
 )
@@ -245,7 +245,7 @@ def block_transactions(
                 s=U256(2),
             ),
         ]
-    elif request.param == "fee_market_transactions":
+    elif request.param == "dynamic_fee_transactions":
         return [
             FeeMarketTransaction(
                 chain_id=U64(0),

--- a/tests/backends/eels/conftest.py
+++ b/tests/backends/eels/conftest.py
@@ -1,3 +1,4 @@
+import pytest
 from typing import (
     Any,
     Dict,
@@ -7,7 +8,6 @@ from typing import (
     Union,
 )
 
-import pytest
 from ethereum.cancun.blocks import (
     Block,
     Header,

--- a/tests/backends/eels/test_eels_serializers.py
+++ b/tests/backends/eels/test_eels_serializers.py
@@ -1,0 +1,215 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Tuple,
+    Union,
+)
+
+from ethereum.cancun.blocks import (
+    Block,
+    Log,
+)
+from ethereum.cancun.transactions import (
+    LegacyTransaction,
+)
+
+from eth_tester.backends.eels.main import (
+    EELSBackend,
+)
+from eth_tester.backends.eels.serializers import (
+    serialize_block,
+    serialize_pending_logs,
+    serialize_pending_receipt,
+    serialize_transaction,
+)
+
+
+def test_serialize_block_returns_camel_case_keys(
+    block: Union[Block, Dict[str, Any]],
+) -> None:
+    is_pending = isinstance(block, dict)
+    if isinstance(block, Block):
+        # Finalized blocks
+        num_transactions = len(block.transactions)
+        num_withdrawals = len(block.withdrawals)
+        transaction = block.transactions[0] if num_transactions > 0 else None
+    elif isinstance(block, dict):
+        # Pending blocks
+        num_transactions = len(block["transactions"])
+        num_withdrawals = len(block["withdrawals"])
+        transaction = block["transactions"][0] if num_transactions > 0 else None
+
+    full_transactions = False if isinstance(transaction, bytes) else True
+
+    serialized_block = serialize_block(
+        EELSBackend(),
+        block,
+        full_transactions=full_transactions,
+        is_pending=is_pending,
+    )
+
+    expected_keys = [
+        "number",
+        "hash",
+        "parentHash",
+        "nonce",
+        "stateRoot",
+        "coinbase",
+        "transactionsRoot",
+        "receiptsRoot",
+        "logsBloom",
+        "gasLimit",
+        "gasUsed",
+        "timestamp",
+        "withdrawalsRoot",
+        "baseFeePerGas",
+        "blobGasUsed",
+        "excessBlobGas",
+        "transactions",
+        "uncles",
+        "withdrawals",
+        "sha3Uncles",
+        "difficulty",
+        "totalDifficulty",
+        "mixHash",
+        "size",
+        "extraData",
+    ]
+
+    if not is_pending:
+        expected_keys.append("parentBeaconBlockRoot")
+
+    assert sorted(list(serialized_block.keys())) == sorted(expected_keys)
+
+    if num_transactions > 0 and full_transactions:
+        txns: List[Dict[str, Any]] = serialized_block["transactions"]
+
+        for txn in txns:
+            valid_transaction_keys = [
+                "type",
+                "hash",
+                "nonce",
+                "blockHash",
+                "blockNumber",
+                "transactionIndex",
+                "gas",
+                "to",
+                "from",
+                "value",
+                "data",
+                "r",
+                "s",
+                "v",
+                "gasPrice",
+                "chainId",
+                "maxPriorityFeePerGas",
+                "maxFeePerGas",
+                "accessList",
+                "maxFeePerBlobGas",
+                "blobVersionedHashes",
+                "yParity",
+            ]
+
+            # Check all transaction keys are valid
+            for key in txn.keys():
+                assert (
+                    key in valid_transaction_keys
+                ), f"Invalid transaction key found: {key}"
+
+    if num_withdrawals > 0:
+        withdrawals = serialized_block["withdrawals"]
+
+        for withdrawal in withdrawals:
+            valid_withdrawal_keys = [
+                "index",
+                "validatorIndex",
+                "address",
+                "amount",
+            ]
+
+            # Check all withdrawal keys are valid
+            for key in withdrawal.keys():
+                assert (
+                    key in valid_withdrawal_keys
+                ), f"Invalid withdrawal key found: {key}"
+
+
+def test_serialize_transaction_returns_camel_case_keys(
+    transaction_dict: Dict[str, Any],
+    parameterized_pending_block: Union[None, Dict[str, Any]],
+) -> None:
+    additional_expected_keys = []
+    if parameterized_pending_block is not None:
+        serialized_transaction = serialize_transaction(
+            transaction_dict, parameterized_pending_block
+        )
+
+        additional_expected_keys = [
+            "blockHash",
+            "blockNumber",
+            "transactionIndex",
+        ]
+    else:
+        serialized_transaction = serialize_transaction(transaction_dict)
+
+    expected_keys = [
+        "nonce",
+        "to",
+        "value",
+        "gas",
+        "gasPrice",
+        "data",
+        "v",
+        "r",
+        "s",
+    ]
+    expected_keys.extend(additional_expected_keys)
+
+    assert sorted(list(serialized_transaction.keys())) == sorted(expected_keys)
+
+
+def test_serialize_transaction_receipt(
+    transaction: LegacyTransaction, process_transaction_return: Tuple[int, Log, int]
+) -> None:
+    serialized_receipt = serialize_pending_receipt(
+        EELSBackend(),
+        tx=transaction,
+        process_transaction_return=process_transaction_return,
+        index=0,
+        cumulative_gas_used=0,
+        contract_address=None,
+    )
+
+    expected_keys = [
+        "blockHash",
+        "blockNumber",
+        "contractAddress",
+        "cumulativeGasUsed",
+        "effectiveGasPrice",
+        "from",
+        "gasUsed",
+        "logs",
+        "stateRoot",
+        "status",
+        "to",
+        "transactionHash",
+        "transactionIndex",
+        "type",
+    ]
+
+    assert sorted(list(serialized_receipt.keys())) == sorted(expected_keys)
+
+
+def test_serialize_pending_logs(log: Log) -> None:
+    serialized_pending_logs = serialize_pending_logs((log,))
+
+    expected_keys = [
+        "address",
+        "topics",
+        "data",
+        "logIndex",
+        "type",
+    ]
+
+    assert sorted(list(serialized_pending_logs[0].keys())) == sorted(expected_keys)

--- a/tests/backends/pyevm/conftest.py
+++ b/tests/backends/pyevm/conftest.py
@@ -1,0 +1,676 @@
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+import pytest
+from eth.abc import (
+    BlockAPI,
+    BlockHeaderAPI,
+    BlockNumber,
+    Hash32,
+    LogAPI,
+    ReceiptAPI,
+    WithdrawalAPI,
+)
+from eth.vm.forks.cancun.transactions import (
+    TypedTransaction,
+)
+from eth_typing import (
+    Address,
+)
+
+from eth_tester import (
+    EthereumTester,
+    PyEVMBackend,
+)
+from eth_tester.backends.pyevm.utils import (
+    is_supported_pyevm_version_available,
+)
+from eth_tester.constants import (
+    ZERO_ADDRESS,
+    ZERO_HASH32,
+)
+
+
+class FakeState:
+    def __init__(self, blob_base_fee: int) -> None:
+        self.blob_base_fee = blob_base_fee
+
+
+class FakeVM:
+    def __init__(self, state: FakeState = FakeState(1)) -> None:
+        self.state = state
+
+
+class FakeWithdrawal(WithdrawalAPI):
+    def __init__(
+        self,
+        index: int = 0,
+        validator_index: int = 0,
+        address: Address = Address(ZERO_ADDRESS),
+        amount: int = 0,
+    ) -> None:
+        self._index = index
+        self._validator_index = validator_index
+        self._address = address
+        self._amount = amount
+
+    # These are the abstract properties required by WithdrawalAPI
+    @property
+    def index(self) -> int:
+        return self._index
+
+    @property
+    def validator_index(self) -> int:
+        return self._validator_index
+
+    @property
+    def address(self) -> Address:
+        return self._address
+
+    @property
+    def amount(self) -> int:
+        return self._amount
+
+    @property
+    def hash(self) -> Hash32:
+        return Hash32(b"\x00" * 32)
+
+    def validate(self) -> None:
+        pass
+
+    def encode(self) -> bytes:
+        return b""
+
+
+@pytest.fixture
+def withdrawal() -> FakeWithdrawal:
+    return FakeWithdrawal(
+        index=0,
+        validator_index=0,
+        address=Address(ZERO_ADDRESS),
+        amount=0,
+    )
+
+
+class FakeBlockHeader(BlockHeaderAPI):
+    def __init__(
+        self,
+        block_number: BlockNumber = BlockNumber(0),
+        hash: bytes = b"",
+        parent_hash: Hash32 = Hash32(ZERO_HASH32),
+        uncles_hash: Hash32 = Hash32(ZERO_HASH32),
+        mix_hash: Hash32 = Hash32(ZERO_HASH32),
+        coinbase: Address = Address(ZERO_ADDRESS),
+        transaction_root: Hash32 = Hash32(ZERO_HASH32),
+        receipt_root: Hash32 = Hash32(ZERO_HASH32),
+        state_root: Hash32 = Hash32(ZERO_HASH32),
+        nonce: bytes = b"",
+        bloom: int = 0,
+        difficulty: int = 0,
+        extra_data: bytes = b"",
+        gas_limit: int = 0,
+        gas_used: int = 0,
+        timestamp: int = 0,
+        blob_gas_used: int = 0,
+        excess_blob_gas: int = 0,
+        base_fee_per_gas: int = 1,
+        withdrawals_root: Optional[Hash32] = None,
+        parent_beacon_block_root: Optional[Hash32] = None,
+    ) -> None:
+        self.block_number = block_number
+        self._hash = hash
+        self.parent_hash = parent_hash
+        self.uncles_hash = uncles_hash
+        self.mix_hash = mix_hash
+        self.coinbase = coinbase
+        self.transaction_root = transaction_root
+        self.receipt_root = receipt_root
+        self.state_root = state_root
+        self.nonce = nonce
+        self.bloom = bloom
+        self.difficulty = difficulty
+        self.extra_data = extra_data
+        self.gas_limit = gas_limit
+        self.gas_used = gas_used
+        self.timestamp = timestamp
+        self._withdrawals_root = withdrawals_root
+        self._parent_beacon_block_root = parent_beacon_block_root
+        self._blob_gas_used = blob_gas_used
+        self._excess_blob_gas = excess_blob_gas
+        self._base_fee_per_gas = base_fee_per_gas
+
+    @property
+    def hash(self) -> Hash32:
+        return Hash32(self._hash if self._hash else ZERO_HASH32)
+
+    @property
+    def mining_hash(self) -> Hash32:
+        return Hash32(self._hash if self._hash else ZERO_HASH32)
+
+    @property
+    def base_fee_per_gas(self) -> Optional[int]:
+        return self._base_fee_per_gas
+
+    @property
+    def withdrawals_root(self) -> Optional[Hash32]:
+        return self._withdrawals_root
+
+    @property
+    def parent_beacon_block_root(self) -> Optional[Hash32]:
+        return self._parent_beacon_block_root
+
+    @property
+    def blob_gas_used(self) -> int:
+        return self._blob_gas_used
+
+    @property
+    def excess_blob_gas(self) -> int:
+        return self._excess_blob_gas
+
+    @property
+    def hex_hash(self) -> str:
+        return self.hash.hex()
+
+    @property
+    def is_genesis(self) -> bool:
+        return self.block_number == 0
+
+    def as_dict(self) -> Dict[Hashable, Any]:
+        return {
+            "block_number": self.block_number,
+            "hash": self.hash,
+            "parent_hash": self.parent_hash,
+            "uncles_hash": self.uncles_hash,
+            "mix_hash": self.mix_hash,
+            "coinbase": self.coinbase,
+            "transaction_root": self.transaction_root,
+            "receipt_root": self.receipt_root,
+            "state_root": self.state_root,
+            "nonce": self.nonce,
+            "bloom": self.bloom,
+            "difficulty": self.difficulty,
+            "extra_data": self.extra_data,
+            "gas_limit": self.gas_limit,
+            "gas_used": self.gas_used,
+            "timestamp": self.timestamp,
+        }
+
+    def build_changeset(self, *args: Any, **kwargs: Any) -> Any:
+        return None
+
+    def copy(self, *args: Any, **kwargs: Any) -> "BlockHeaderAPI":
+        return FakeBlockHeader()
+
+    @classmethod
+    def deserialize(cls, encoded: List[bytes]) -> "BlockHeaderAPI":
+        return FakeBlockHeader()
+
+    @classmethod
+    def serialize(cls, obj: "BlockHeaderAPI") -> List[bytes]:
+        return []
+
+
+class FakeLog(LogAPI):
+    def __init__(
+        self,
+        address: Address = Address(ZERO_ADDRESS),
+        data: bytes = b"",
+        topics: Sequence[int] = (),
+    ) -> None:
+        self.address = address
+        self.data = data
+        self.topics = topics
+
+    @property
+    def bloomables(self) -> Tuple[bytes, ...]:
+        return ()
+
+
+class FakeReceipt(ReceiptAPI):
+    def __init__(
+        self,
+        state_root: bytes = b"",
+        gas_used: int = 0,
+        logs: Sequence[FakeLog] = (),
+        bloom: int = 0,
+        bloom_filter: int = 0,
+    ) -> None:
+        self._gas_used = gas_used
+        self._logs = logs
+        self._state_root = state_root
+        self._bloom = bloom
+        self._bloom_filter = bloom_filter
+        self._logs = logs
+
+    @property
+    def gas_used(self) -> int:
+        return self._gas_used
+
+    @property
+    def state_root(self) -> bytes:
+        return self._state_root
+
+    @property
+    def logs(self) -> Sequence[FakeLog]:
+        return self._logs
+
+    @property
+    def bloom(self) -> int:
+        return self._bloom
+
+    @property
+    def bloom_filter(self) -> Any:
+        return self._bloom_filter
+
+    def copy(self, *args: Any, **kwargs: Any) -> "FakeReceipt":
+        return FakeReceipt(
+            state_root=self._state_root,
+            gas_used=self._gas_used,
+            logs=self._logs,
+            bloom=self._bloom,
+            bloom_filter=self._bloom_filter,
+        )
+
+    def encode(self) -> bytes:
+        return b""
+
+
+class FakeSetCodeAuthorization:
+    def __init__(
+        self,
+        chain_id: int = 0,
+        address: Address = Address(ZERO_ADDRESS),
+        nonce: int = 0,
+        y_parity: int = 0,
+        s: int = 0,
+        r: int = 0,
+    ) -> None:
+        self.chain_id = chain_id
+        self.nonce = nonce
+        self.address = address
+        self.y_parity = y_parity
+        self.s = s
+        self.r = r
+
+    def validate_for_transaction(self) -> None:
+        return
+
+    def validate(self, chain_id: int) -> None:
+        return
+
+
+class FakeTransaction(TypedTransaction):
+    def __init__(
+        self,
+        type_id: Optional[int] = 0,
+        hash: Hash32 = Hash32(ZERO_HASH32),
+        nonce: int = 0,
+        to: Address = Address(ZERO_ADDRESS),
+        _from: Address = Address(ZERO_ADDRESS),
+        sender: Address = Address(ZERO_ADDRESS),
+        value: int = 0,
+        gas: int = 0,
+        data: bytes = b"",
+        s: int = 0,
+        r: int = 0,
+        v: int = 0,
+        authorization_list: Sequence[FakeSetCodeAuthorization] = (
+            FakeSetCodeAuthorization(),
+        ),
+        y_parity: int = 0,
+        chain_id: Optional[int] = None,
+        access_list: Optional[Sequence[Tuple[Address, Sequence[int]]]] = None,
+        gas_price: Optional[int] = None,
+        max_fee_per_gas: Optional[int] = None,
+        max_priority_fee_per_gas: Optional[int] = None,
+        max_fee_per_blob_gas: Optional[int] = None,
+        blob_versioned_hashes: Optional[Sequence[Hash32]] = None,
+    ) -> None:
+        self.type_id = type_id
+        self._hash = hash
+        self._nonce = nonce
+        self._to = to
+        self._from = _from
+        self._sender = sender
+        self._value = value
+        self._gas = gas
+        self._data = data
+        self._s = s
+        self._r = r
+        self._v = v
+        self._authorization_list = authorization_list
+        self._y_parity = y_parity
+
+        if chain_id is not None:
+            self._chain_id = chain_id
+
+        if access_list is not None:
+            self._access_list = access_list
+
+        if gas_price is not None:
+            self._gas_price = gas_price
+
+        if max_fee_per_gas is not None:
+            self._max_fee_per_gas = max_fee_per_gas
+
+        if max_priority_fee_per_gas is not None:
+            self._max_priority_fee_per_gas = max_priority_fee_per_gas
+
+        if max_fee_per_blob_gas is not None:
+            self._max_fee_per_blob_gas = max_fee_per_blob_gas
+
+        if blob_versioned_hashes is not None:
+            self._blob_versioned_hashes = blob_versioned_hashes
+
+    @property
+    def to(self) -> Address:
+        return self._to
+
+    @property
+    def from_(self) -> Address:
+        return self._from
+
+    @property
+    def gas_price(self) -> int:
+        return getattr(self, "_gas_price", 0)
+
+    @property
+    def max_fee_per_gas(self) -> int:
+        return getattr(self, "_max_fee_per_gas", 0)
+
+    @property
+    def max_priority_fee_per_gas(self) -> int:
+        return getattr(self, "_max_priority_fee_per_gas", 0)
+
+    @property
+    def max_fee_per_blob_gas(self) -> int:
+        return getattr(self, "_max_fee_per_blob_gas", 0)
+
+    @property
+    def sender(self) -> Address:
+        return self._sender
+
+    @property
+    def nonce(self) -> int:
+        return self._nonce
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+    @property
+    def gas(self) -> int:
+        return self._gas
+
+    @property
+    def data(self) -> bytes:
+        return self._data
+
+    @property
+    def y_parity(self) -> int:
+        return self._y_parity
+
+    @property
+    def r(self) -> int:
+        return self._r
+
+    @property
+    def s(self) -> int:
+        return self._s
+
+    @property
+    def hash(self) -> Hash32:
+        return Hash32(self._hash if self._hash else ZERO_HASH32)
+
+    @property
+    def v(self) -> int:
+        return self._v
+
+    @property
+    def intrinsic_gas(self) -> int:
+        return 0
+
+    @property
+    def access_list(self) -> Sequence[Tuple[Address, Sequence[int]]]:
+        return getattr(self, "_access_list", ())
+
+    @property
+    def authorization_list(self) -> Sequence[Any]:
+        return self._authorization_list
+
+    @property
+    def blob_versioned_hashes(self) -> Sequence[Hash32]:  # type: ignore
+        # Type ignored, mismatch in parent classes
+        return getattr(self, "_blob_versioned_hashes", ())
+
+    @property
+    def chain_id(self) -> int:
+        return getattr(self, "_chain_id", 0)
+
+    @property
+    def is_signature_valid(self) -> bool:
+        return True
+
+    def check_signature_validity(self) -> None:
+        return None
+
+    def make_receipt(
+        self,
+        status: bytes,
+        gas_used: int,
+        log_entries: Tuple[Tuple[bytes, Tuple[int, ...], bytes], ...],
+    ) -> FakeReceipt:
+        return FakeReceipt()
+
+    def get_sender(self) -> Address:
+        return self._sender
+
+    def get_message_for_signing(self) -> bytes:
+        return b""
+
+    def get_intrinsic_gas(self) -> int:
+        return 0
+
+    def gas_used_by(self, computation: Any) -> int:
+        return 0
+
+    def validate(self) -> None:
+        return
+
+    def encode(self) -> bytes:
+        return b""
+
+    def copy(self, **overrides: Any) -> "FakeTransaction":
+        return FakeTransaction()
+
+
+class FakeBlock(BlockAPI):
+    def __init__(
+        self,
+        header: FakeBlockHeader = FakeBlockHeader(),
+        transactions: Tuple[TypedTransaction, ...] = (),
+        uncles: Tuple[FakeBlockHeader, ...] = (),
+        withdrawals: Tuple[FakeWithdrawal, ...] = (),
+    ) -> None:
+        self.header = header
+        self.transactions = transactions
+        self.uncles = uncles
+
+        if getattr(self.header, "withdrawals_root", None) is not None:
+            self.withdrawals = withdrawals
+        else:
+            self.withdrawals = tuple()
+
+    @property
+    def hash(self) -> Hash32:
+        return Hash32(self.header.hash if self.header.hash else ZERO_HASH32)
+
+    @property
+    def number(self) -> BlockNumber:
+        return self.header.block_number
+
+    @property
+    def is_genesis(self) -> bool:
+        return self.header.is_genesis
+
+    def from_header(self, header):  # type: ignore
+        pass
+
+    def get_transaction_builder(cls):  # type: ignore
+        pass
+
+    def get_receipt_builder(cls):  # type: ignore
+        pass
+
+    def get_receipts(self, chaindb):  # type: ignore
+        pass
+
+    def serialize(self) -> bytes:
+        return b""
+
+    def deserialize(self, data: bytes) -> "FakeBlock":
+        return FakeBlock()
+
+
+@pytest.fixture
+def eth_tester() -> EthereumTester:
+    if not is_supported_pyevm_version_available():
+        pytest.skip("PyEVM is not available")
+    backend = PyEVMBackend()
+    return EthereumTester(backend=backend)
+
+
+@pytest.fixture
+def accounts_from_mnemonic() -> List[str]:
+    return [
+        "0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C",
+        "0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7",
+        "0x318b469BBa396AEc2C60342F9441be36A1945174",
+    ]
+
+
+# Transaction fixtures
+
+
+@pytest.fixture(
+    params=[
+        "legacy_transactions",
+        "blob_transactions",
+        "fee_market_transactions",
+        "access_list_transactions",
+    ]
+)
+def transaction(
+    request: pytest.FixtureRequest,
+) -> FakeTransaction:
+    if request.param == "access_list_transactions":
+        return FakeTransaction(type_id=1, hash=Hash32(ZERO_HASH32))
+    elif request.param == "fee_market_transactions":
+        return FakeTransaction(type_id=2, hash=Hash32(ZERO_HASH32))
+    elif request.param == "blob_transactions":
+        return FakeTransaction(type_id=3, hash=Hash32(ZERO_HASH32))
+
+    return FakeTransaction(type_id=0, hash=Hash32(ZERO_HASH32))
+
+
+# Block fixtures
+
+
+@pytest.fixture(params=["zero", "one"], ids=["zero_withdrawals", "one_withdrawal"])
+def withdrawals(request: pytest.FixtureRequest) -> Tuple[FakeWithdrawal, ...]:
+    if request.param == "one":
+        return (FakeWithdrawal(),)
+    else:
+        return ()
+
+
+@pytest.fixture(
+    params=[
+        "no_transactions",
+        "legacy_transactions",
+        "blob_transactions",
+        "fee_market_transactions",
+        "access_list_transactions",
+    ]
+)
+def block_transactions(
+    request: pytest.FixtureRequest,
+) -> Tuple[FakeTransaction, ...]:
+    if request.param == "legacy_transactions":
+        return tuple(
+            [FakeTransaction(type_id=0, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+        )
+    elif request.param == "access_list_transactions":
+        return tuple(
+            [FakeTransaction(type_id=1, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+        )
+    elif request.param == "fee_market_transactions":
+        return tuple(
+            [FakeTransaction(type_id=2, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+        )
+    elif request.param == "blob_transactions":
+        return tuple(
+            [FakeTransaction(type_id=3, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+        )
+
+    return ()
+
+
+@pytest.fixture(
+    params=[
+        {},
+        {"base_fee_per_gas": 1},
+        {"withdrawals_root": Hash32(ZERO_HASH32)},
+        {
+            "base_fee_per_gas": 1,
+            "withdrawals_root": Hash32(ZERO_HASH32),
+            "parent_beacon_block_root": Hash32(ZERO_HASH32),
+        },
+    ],
+    ids=[
+        "legacy_block_header",
+        "london_block_header",
+        "shanghai_block_header",
+        "cancun_block_header",
+    ],
+)
+def block_header(request: pytest.FixtureRequest) -> FakeBlockHeader:
+    kwargs = request.param
+    return FakeBlockHeader(
+        **kwargs,
+    )
+
+
+@pytest.fixture
+def block(
+    block_header: FakeBlockHeader,
+    block_transactions: Tuple[FakeTransaction, ...],
+    withdrawals: Tuple[FakeWithdrawal, ...],
+) -> FakeBlock:
+    return FakeBlock(
+        header=block_header,
+        transactions=block_transactions,
+        uncles=(),
+        withdrawals=withdrawals,
+    )
+
+
+# Transaction receipt fixtures
+
+
+@pytest.fixture
+def transaction_receipts() -> List[FakeReceipt]:
+    return [
+        FakeReceipt(
+            state_root=Hash32(ZERO_HASH32),
+            gas_used=0,
+            logs=[FakeLog(Address(ZERO_ADDRESS), b"", ())],
+        )
+    ]

--- a/tests/backends/pyevm/conftest.py
+++ b/tests/backends/pyevm/conftest.py
@@ -563,7 +563,7 @@ def accounts_from_mnemonic() -> List[str]:
     params=[
         "legacy_transactions",
         "blob_transactions",
-        "fee_market_transactions",
+        "dynamic_fee_transactions",
         "access_list_transactions",
     ]
 )
@@ -572,7 +572,7 @@ def transaction(
 ) -> FakeTransaction:
     if request.param == "access_list_transactions":
         return FakeTransaction(type_id=1, hash=Hash32(ZERO_HASH32))
-    elif request.param == "fee_market_transactions":
+    elif request.param == "dynamic_fee_transactions":
         return FakeTransaction(type_id=2, hash=Hash32(ZERO_HASH32))
     elif request.param == "blob_transactions":
         return FakeTransaction(type_id=3, hash=Hash32(ZERO_HASH32))
@@ -596,7 +596,7 @@ def withdrawals(request: pytest.FixtureRequest) -> Tuple[FakeWithdrawal, ...]:
         "no_transactions",
         "legacy_transactions",
         "blob_transactions",
-        "fee_market_transactions",
+        "dynamic_fee_transactions",
         "access_list_transactions",
     ]
 )
@@ -611,7 +611,7 @@ def block_transactions(
         return tuple(
             [FakeTransaction(type_id=1, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
         )
-    elif request.param == "fee_market_transactions":
+    elif request.param == "dynamic_fee_transactions":
         return tuple(
             [FakeTransaction(type_id=2, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
         )

--- a/tests/backends/pyevm/conftest.py
+++ b/tests/backends/pyevm/conftest.py
@@ -1,3 +1,4 @@
+import pytest
 from typing import (
     Any,
     Dict,
@@ -8,7 +9,6 @@ from typing import (
     Tuple,
 )
 
-import pytest
 from eth.vm.forks.cancun.transactions import (
     TypedTransaction,
 )
@@ -62,14 +62,19 @@ else:
         pass
 
 
+DEFAULT_ZERO_ADDRESS = Address(ZERO_ADDRESS)
+DEFAULT_ZERO_HASH32 = Hash32(ZERO_HASH32)
+DEFAULT_BLOCK_NUMBER = BlockNumber(0)
+
+
 class FakeState:
-    def __init__(self, blob_base_fee: int) -> None:
+    def __init__(self, blob_base_fee: int = 1) -> None:
         self.blob_base_fee = blob_base_fee
 
 
 class FakeVM:
-    def __init__(self, state: FakeState = FakeState(1)) -> None:
-        self.state = state
+    def __init__(self, state: FakeState) -> None:
+        self.state = state if state else FakeState(1)
 
 
 class FakeWithdrawal(WithdrawalAPI):
@@ -77,7 +82,7 @@ class FakeWithdrawal(WithdrawalAPI):
         self,
         index: int = 0,
         validator_index: int = 0,
-        address: Address = Address(ZERO_ADDRESS),
+        address: Address = DEFAULT_ZERO_ADDRESS,
         amount: int = 0,
     ) -> None:
         self._index = index
@@ -118,7 +123,7 @@ def withdrawal() -> FakeWithdrawal:
     return FakeWithdrawal(
         index=0,
         validator_index=0,
-        address=Address(ZERO_ADDRESS),
+        address=DEFAULT_ZERO_ADDRESS,
         amount=0,
     )
 
@@ -126,15 +131,15 @@ def withdrawal() -> FakeWithdrawal:
 class FakeBlockHeader(BlockHeaderAPI):
     def __init__(
         self,
-        block_number: BlockNumber = BlockNumber(0),
+        block_number: BlockNumber = DEFAULT_BLOCK_NUMBER,
         hash: bytes = b"",
-        parent_hash: Hash32 = Hash32(ZERO_HASH32),
-        uncles_hash: Hash32 = Hash32(ZERO_HASH32),
-        mix_hash: Hash32 = Hash32(ZERO_HASH32),
-        coinbase: Address = Address(ZERO_ADDRESS),
-        transaction_root: Hash32 = Hash32(ZERO_HASH32),
-        receipt_root: Hash32 = Hash32(ZERO_HASH32),
-        state_root: Hash32 = Hash32(ZERO_HASH32),
+        parent_hash: Hash32 = DEFAULT_ZERO_HASH32,
+        uncles_hash: Hash32 = DEFAULT_ZERO_HASH32,
+        mix_hash: Hash32 = DEFAULT_ZERO_HASH32,
+        coinbase: Address = DEFAULT_ZERO_ADDRESS,
+        transaction_root: Hash32 = DEFAULT_ZERO_HASH32,
+        receipt_root: Hash32 = DEFAULT_ZERO_HASH32,
+        state_root: Hash32 = DEFAULT_ZERO_HASH32,
         nonce: bytes = b"",
         bloom: int = 0,
         difficulty: int = 0,
@@ -244,7 +249,7 @@ class FakeBlockHeader(BlockHeaderAPI):
 class FakeLog(LogAPI):
     def __init__(
         self,
-        address: Address = Address(ZERO_ADDRESS),
+        address: Address = DEFAULT_ZERO_ADDRESS,
         data: bytes = b"",
         topics: Sequence[int] = (),
     ) -> None:
@@ -310,7 +315,7 @@ class FakeSetCodeAuthorization:
     def __init__(
         self,
         chain_id: int = 0,
-        address: Address = Address(ZERO_ADDRESS),
+        address: Address = DEFAULT_ZERO_ADDRESS,
         nonce: int = 0,
         y_parity: int = 0,
         s: int = 0,
@@ -330,15 +335,18 @@ class FakeSetCodeAuthorization:
         return
 
 
+DEFAULT_AUTHORIZATION_LIST = FakeSetCodeAuthorization()
+
+
 class FakeTransaction(TypedTransaction):
     def __init__(
         self,
         type_id: Optional[int] = 0,
-        hash: Hash32 = Hash32(ZERO_HASH32),
+        hash: Hash32 = DEFAULT_ZERO_HASH32,
         nonce: int = 0,
-        to: Address = Address(ZERO_ADDRESS),
-        _from: Address = Address(ZERO_ADDRESS),
-        sender: Address = Address(ZERO_ADDRESS),
+        to: Address = DEFAULT_ZERO_ADDRESS,
+        _from: Address = DEFAULT_ZERO_ADDRESS,
+        sender: Address = DEFAULT_ZERO_ADDRESS,
         value: int = 0,
         gas: int = 0,
         data: bytes = b"",
@@ -346,7 +354,7 @@ class FakeTransaction(TypedTransaction):
         r: int = 0,
         v: int = 0,
         authorization_list: Sequence[FakeSetCodeAuthorization] = (
-            FakeSetCodeAuthorization(),
+            DEFAULT_AUTHORIZATION_LIST,
         ),
         y_parity: int = 0,
         chain_id: Optional[int] = None,
@@ -515,10 +523,13 @@ class FakeTransaction(TypedTransaction):
         return FakeTransaction()
 
 
+DEFAULT_BLOCK_HEADER = FakeBlockHeader()
+
+
 class FakeBlock(BlockAPI):
     def __init__(
         self,
-        header: FakeBlockHeader = FakeBlockHeader(),
+        header: FakeBlockHeader = DEFAULT_BLOCK_HEADER,
         transactions: Tuple[TypedTransaction, ...] = (),
         uncles: Tuple[FakeBlockHeader, ...] = (),
         withdrawals: Tuple[FakeWithdrawal, ...] = (),
@@ -595,13 +606,13 @@ def transaction(
     request: pytest.FixtureRequest,
 ) -> FakeTransaction:
     if request.param == "access_list_transactions":
-        return FakeTransaction(type_id=1, hash=Hash32(ZERO_HASH32))
+        return FakeTransaction(type_id=1, hash=DEFAULT_ZERO_HASH32)
     elif request.param == "dynamic_fee_transactions":
-        return FakeTransaction(type_id=2, hash=Hash32(ZERO_HASH32))
+        return FakeTransaction(type_id=2, hash=DEFAULT_ZERO_HASH32)
     elif request.param == "blob_transactions":
-        return FakeTransaction(type_id=3, hash=Hash32(ZERO_HASH32))
+        return FakeTransaction(type_id=3, hash=DEFAULT_ZERO_HASH32)
 
-    return FakeTransaction(type_id=0, hash=Hash32(ZERO_HASH32))
+    return FakeTransaction(type_id=0, hash=DEFAULT_ZERO_HASH32)
 
 
 # Block fixtures
@@ -629,19 +640,19 @@ def block_transactions(
 ) -> Tuple[FakeTransaction, ...]:
     if request.param == "legacy_transactions":
         return tuple(
-            [FakeTransaction(type_id=0, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+            [FakeTransaction(type_id=0, hash=DEFAULT_ZERO_HASH32) for _ in range(3)]
         )
     elif request.param == "access_list_transactions":
         return tuple(
-            [FakeTransaction(type_id=1, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+            [FakeTransaction(type_id=1, hash=DEFAULT_ZERO_HASH32) for _ in range(3)]
         )
     elif request.param == "dynamic_fee_transactions":
         return tuple(
-            [FakeTransaction(type_id=2, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+            [FakeTransaction(type_id=2, hash=DEFAULT_ZERO_HASH32) for _ in range(3)]
         )
     elif request.param == "blob_transactions":
         return tuple(
-            [FakeTransaction(type_id=3, hash=Hash32(ZERO_HASH32)) for _ in range(3)]
+            [FakeTransaction(type_id=3, hash=DEFAULT_ZERO_HASH32) for _ in range(3)]
         )
 
     return ()
@@ -651,11 +662,11 @@ def block_transactions(
     params=[
         {},
         {"base_fee_per_gas": 1},
-        {"withdrawals_root": Hash32(ZERO_HASH32)},
+        {"withdrawals_root": DEFAULT_ZERO_HASH32},
         {
             "base_fee_per_gas": 1,
-            "withdrawals_root": Hash32(ZERO_HASH32),
-            "parent_beacon_block_root": Hash32(ZERO_HASH32),
+            "withdrawals_root": DEFAULT_ZERO_HASH32,
+            "parent_beacon_block_root": DEFAULT_ZERO_HASH32,
         },
     ],
     ids=[
@@ -693,8 +704,8 @@ def block(
 def transaction_receipts() -> List[FakeReceipt]:
     return [
         FakeReceipt(
-            state_root=Hash32(ZERO_HASH32),
+            state_root=DEFAULT_ZERO_HASH32,
             gas_used=0,
-            logs=[FakeLog(Address(ZERO_ADDRESS), b"", ())],
+            logs=[FakeLog(DEFAULT_ZERO_ADDRESS, b"", ())],
         )
     ]

--- a/tests/backends/pyevm/conftest.py
+++ b/tests/backends/pyevm/conftest.py
@@ -9,15 +9,6 @@ from typing import (
 )
 
 import pytest
-from eth.abc import (
-    BlockAPI,
-    BlockHeaderAPI,
-    BlockNumber,
-    Hash32,
-    LogAPI,
-    ReceiptAPI,
-    WithdrawalAPI,
-)
 from eth.vm.forks.cancun.transactions import (
     TypedTransaction,
 )
@@ -36,6 +27,39 @@ from eth_tester.constants import (
     ZERO_ADDRESS,
     ZERO_HASH32,
 )
+
+if is_supported_pyevm_version_available():
+    from eth.abc import (
+        BlockAPI,
+        BlockHeaderAPI,
+        BlockNumber,
+        Hash32,
+        LogAPI,
+        ReceiptAPI,
+        WithdrawalAPI,
+    )
+else:
+
+    class BlockAPI:
+        pass
+
+    class BlockHeaderAPI:
+        pass
+
+    class BlockNumber:
+        pass
+
+    class Hash32:
+        pass
+
+    class LogAPI:
+        pass
+
+    class ReceiptAPI:
+        pass
+
+    class WithdrawalAPI:
+        pass
 
 
 class FakeState:

--- a/tests/backends/pyevm/test_pyevm.py
+++ b/tests/backends/pyevm/test_pyevm.py
@@ -1,5 +1,4 @@
 import pytest
-
 from eth.constants import (
     POST_MERGE_DIFFICULTY,
     POST_MERGE_MIX_HASH,
@@ -25,6 +24,8 @@ from eth_typing import (
 )
 from eth_utils import (
     ValidationError as EthUtilsValidationError,
+)
+from eth_utils import (
     encode_hex,
     is_hexstr,
     to_hex,
@@ -46,6 +47,9 @@ from eth_tester.backends.pyevm.main import (
 from eth_tester.backends.pyevm.utils import (
     is_supported_pyevm_version_available,
 )
+from eth_tester.constants import (
+    ZERO_ADDRESS_HEX,
+)
 from eth_tester.exceptions import (
     BlockNotFound,
     ValidationError,
@@ -61,25 +65,7 @@ from eth_tester.utils.backend_testing import (
     BaseTestBackendDirect,
 )
 
-ZERO_ADDRESS_HEX = "0x0000000000000000000000000000000000000000"
 MNEMONIC = "test test test test test test test test test test test junk"
-
-
-@pytest.fixture
-def eth_tester():
-    if not is_supported_pyevm_version_available():
-        pytest.skip("PyEVM is not available")
-    backend = PyEVMBackend()
-    return EthereumTester(backend=backend)
-
-
-@pytest.fixture
-def accounts_from_mnemonic():
-    return [
-        "0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C",
-        "0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7",
-        "0x318b469BBa396AEc2C60342F9441be36A1945174",
-    ]
 
 
 def test_custom_virtual_machines():
@@ -113,13 +99,13 @@ def test_custom_virtual_machines():
 
 
 @pytest.mark.parametrize(
-    "vm_class_missing_the_field,vm_class_with_new_field,new_field",
+    "vm_class_missing_the_field,vm_class_with_new_field,new_field,",
     (
-        (BerlinVM, LondonVM, "base_fee_per_gas"),
+        (BerlinVM, LondonVM, "baseFeePerGas"),
         (ParisVM, ShanghaiVM, "withdrawals"),
-        (ParisVM, ShanghaiVM, "withdrawals_root"),
-        (ShanghaiVM, CancunVM, "blob_gas_used"),
-        (ShanghaiVM, CancunVM, "excess_blob_gas"),
+        (ParisVM, ShanghaiVM, "withdrawalsRoot"),
+        (ShanghaiVM, CancunVM, "blobGasUsed"),
+        (ShanghaiVM, CancunVM, "excessBlobGas"),
     ),
 )
 def test_newly_introduced_block_fields_at_fork_transition(
@@ -158,7 +144,7 @@ def test_london_configuration():
 
     backend = PyEVMBackend(vm_configuration=((0, LondonVM),))
 
-    assert backend.get_block_by_number(0)["base_fee_per_gas"] == 1000000000
+    assert backend.get_block_by_number(0)["baseFeePerGas"] == 1000000000
 
     EthereumTester(backend=backend)
 
@@ -194,12 +180,10 @@ def test_apply_withdrawals():
     )
     # withdrawal amounts are in gwei, balance is measured in wei
     assert backend.get_balance(b"\x01" * 20) == 100 * 10**9  # 100 gwei
-    assert (
-        backend.get_balance(b"\x02" * 20) == (2**64 - 1) * 10**9
-    )  # 2**64 - 1 gwei
+    assert backend.get_balance(b"\x02" * 20) == (2**64 - 1) * 10**9  # 2**64 - 1 gwei
 
     assert (
-        mined_block["withdrawals_root"]
+        mined_block["withdrawalsRoot"]
         == "0xbb49834f60c98815399dfb1a3303cc0f80984c4c7533ecf326bc343d8109127e"
     )
 
@@ -439,9 +423,9 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
         assert len(accounts) == 3
 
         for acct in accounts:
-            assert tester.get_storage_at(acct, HexStr("0x0")) == f"0x{'00'*32}"
-            assert tester.get_storage_at(acct, HexStr("0x1")) == f"0x{'00'*31}01"
-            assert tester.get_storage_at(acct, HexStr("0x2")) == f"0x{'00'*31}02"
+            assert tester.get_storage_at(acct, HexStr("0x0")) == f"0x{'00' * 32}"
+            assert tester.get_storage_at(acct, HexStr("0x1")) == f"0x{'00' * 31}01"
+            assert tester.get_storage_at(acct, HexStr("0x2")) == f"0x{'00' * 31}02"
 
     # --- cancun network upgrade --- #
 

--- a/tests/backends/pyevm/test_pyevm.py
+++ b/tests/backends/pyevm/test_pyevm.py
@@ -1,4 +1,5 @@
 import pytest
+
 from eth.constants import (
     POST_MERGE_DIFFICULTY,
     POST_MERGE_MIX_HASH,
@@ -24,8 +25,6 @@ from eth_typing import (
 )
 from eth_utils import (
     ValidationError as EthUtilsValidationError,
-)
-from eth_utils import (
     encode_hex,
     is_hexstr,
     to_hex,
@@ -180,7 +179,9 @@ def test_apply_withdrawals():
     )
     # withdrawal amounts are in gwei, balance is measured in wei
     assert backend.get_balance(b"\x01" * 20) == 100 * 10**9  # 100 gwei
-    assert backend.get_balance(b"\x02" * 20) == (2**64 - 1) * 10**9  # 2**64 - 1 gwei
+    assert (
+        backend.get_balance(b"\x02" * 20) == (2**64 - 1) * 10**9
+    )  # 2**64 - 1 gwei
 
     assert (
         mined_block["withdrawalsRoot"]

--- a/tests/backends/pyevm/test_pyevm_serializers.py
+++ b/tests/backends/pyevm/test_pyevm_serializers.py
@@ -1,9 +1,9 @@
+import pytest
 from typing import (
     List,
     Tuple,
 )
 
-import pytest
 from eth.vm.forks.berlin.transactions import (
     TypedTransaction,
 )

--- a/tests/backends/pyevm/test_pyevm_serializers.py
+++ b/tests/backends/pyevm/test_pyevm_serializers.py
@@ -1,0 +1,288 @@
+from typing import (
+    List,
+    Tuple,
+)
+
+import pytest
+from eth.vm.forks.berlin.transactions import (
+    TypedTransaction,
+)
+
+from eth_tester.backends.pyevm.serializers import (
+    serialize_block,
+    serialize_block_withdrawals,
+    serialize_log,
+    serialize_transaction,
+    serialize_transaction_receipt,
+)
+from eth_tester.backends.pyevm.utils import (
+    is_cancun_block,
+    is_london_block,
+    is_shanghai_block,
+)
+from eth_tester.constants import (
+    ACCESS_LIST_TX_TYPE,
+    BLOB_TX_TYPE,
+    DYNAMIC_FEE_TX_TYPE,
+)
+from tests.backends.pyevm.conftest import (
+    FakeBlock,
+    FakeLog,
+    FakeReceipt,
+    FakeState,
+    FakeTransaction,
+    FakeVM,
+    FakeWithdrawal,
+)
+
+
+@pytest.mark.parametrize(
+    "full_transaction", [True, False], ids=["txn_full", "txn_hashes"]
+)
+@pytest.mark.parametrize("is_pending", [True, False], ids=["pending", "finalized"])
+def test_serialize_block_returns_camel_case_keys(
+    block: FakeBlock,
+    full_transaction: bool,
+    is_pending: bool,
+) -> None:
+    serialized_block = serialize_block(
+        block=block,
+        full_transaction=full_transaction,
+        is_pending=is_pending,
+    )
+
+    # Base expected keys
+    expected_keys = [
+        "coinbase",
+        "difficulty",
+        "extraData",
+        "gasLimit",
+        "gasUsed",
+        "hash",
+        "logsBloom",
+        "mixHash",
+        "nonce",
+        "number",
+        "parentHash",
+        "receiptsRoot",
+        "sha3Uncles",
+        "size",
+        "stateRoot",
+        "timestamp",
+        "totalDifficulty",
+        "transactions",
+        "transactionsRoot",
+        "uncles",
+    ]
+
+    # Add any extra expected keys based on parameters
+    if is_london_block(block):
+        expected_keys.append("baseFeePerGas")
+    if is_shanghai_block(block):
+        expected_keys.append("withdrawalsRoot")
+        expected_keys.append("withdrawals")
+    if is_cancun_block(block):
+        expected_keys.append("parentBeaconBlockRoot")
+        expected_keys.append("blobGasUsed")
+        expected_keys.append("excessBlobGas")
+
+    assert sorted(list(serialized_block.keys())) == sorted(expected_keys)
+
+    # Additional assertions to verify transaction format
+    if full_transaction:
+        for txn in serialized_block["transactions"]:
+            valid_transaction_keys = [
+                "type",
+                "hash",
+                "nonce",
+                "blockHash",
+                "blockNumber",
+                "transactionIndex",
+                "from",
+                "gas",
+                "to",
+                "value",
+                "data",
+                "gasPrice",
+                "chainId",
+                "accessList",
+                "maxFeePerGas",
+                "maxPriorityFeePerGas",
+                "maxFeePerBlobGas",
+                "blobVersionedHashes",
+                "r",
+                "s",
+                "v",
+                "yParity",
+            ]
+
+            assert isinstance(txn, dict)
+            for key in txn.keys():
+                if key not in valid_transaction_keys:
+                    assert (
+                        key in valid_transaction_keys
+                    ), f"Invalid transaction key found: {key}"
+    else:
+        for txn in serialized_block["transactions"]:
+            assert isinstance(txn, bytes)
+            assert len(txn) == 32
+
+
+@pytest.mark.parametrize("is_pending", [True, False], ids=["pending", "finalized"])
+def test_serialize_transaction_returns_camel_case_keys(
+    transaction: TypedTransaction,
+    is_pending: bool,
+) -> None:
+    block = FakeBlock(transactions=(transaction,))
+
+    expected_keys = [
+        "blockHash",
+        "blockNumber",
+        "transactionIndex",
+        "gasPrice",
+        "type",
+        "data",
+        "from",
+        "gas",
+        "hash",
+        "nonce",
+        "to",
+        "value",
+        "r",
+        "s",
+        "v",
+    ]
+
+    # Add any extra expected keys based on parameters
+    if transaction.type_id == ACCESS_LIST_TX_TYPE:
+        expected_keys.append("chainId")
+        expected_keys.append("accessList")
+        expected_keys.append("yParity")
+    elif transaction.type_id == DYNAMIC_FEE_TX_TYPE:
+        expected_keys.append("chainId")
+        expected_keys.append("accessList")
+        expected_keys.append("maxFeePerGas")
+        expected_keys.append("maxPriorityFeePerGas")
+        expected_keys.append("yParity")
+    elif transaction.type_id == BLOB_TX_TYPE:
+        expected_keys.append("chainId")
+        expected_keys.append("accessList")
+        expected_keys.append("maxFeePerGas")
+        expected_keys.append("maxPriorityFeePerGas")
+        expected_keys.append("maxFeePerBlobGas")
+        expected_keys.append("blobVersionedHashes")
+        expected_keys.append("yParity")
+
+    serialized_transaction = serialize_transaction(
+        block=block,
+        transaction=transaction,
+        transaction_index=0,
+        is_pending=is_pending,
+    )
+
+    assert sorted(list(serialized_transaction.keys())) == sorted(expected_keys)
+
+
+def test_serialize_transaction_receipt_returns_camel_case_keys(
+    transaction: FakeTransaction,
+    transaction_receipts: List[FakeReceipt],
+) -> None:
+    block = FakeBlock(transactions=(transaction,))
+
+    # Create VM with state
+    state = FakeState(blob_base_fee=1)
+    vm = FakeVM(state=state)
+
+    expected_keys = [
+        "blockHash",
+        "blockNumber",
+        "contractAddress",
+        "cumulativeGasUsed",
+        "effectiveGasPrice",
+        "from",
+        "gasUsed",
+        "logs",
+        "stateRoot",
+        "status",
+        "to",
+        "transactionHash",
+        "transactionIndex",
+        "type",
+    ]
+
+    serialized_receipt = serialize_transaction_receipt(
+        block=block,
+        receipts=transaction_receipts,
+        transaction=transaction,
+        transaction_index=0,
+        is_pending=False,
+        vm=vm,
+    )
+
+    if transaction.type_id == BLOB_TX_TYPE:
+        expected_keys.append("blobGasUsed")
+        expected_keys.append("blobGasPrice")
+
+    assert sorted(list(serialized_receipt.keys())) == sorted(expected_keys)
+
+    for serialized_log in serialized_receipt["logs"]:
+        expected_log_keys = [
+            "type",
+            "logIndex",
+            "transactionIndex",
+            "transactionHash",
+            "blockHash",
+            "blockNumber",
+            "address",
+            "data",
+            "topics",
+        ]
+        assert sorted(list(serialized_log.keys())) == sorted(expected_log_keys)
+
+
+def test_serialize_log_returns_camel_case_keys() -> None:
+    transaction = FakeTransaction()
+    block = FakeBlock(transactions=(transaction,))
+
+    log = FakeLog()
+
+    serialized_log = serialize_log(
+        block=block,
+        transaction=transaction,
+        transaction_index=0,
+        log=log,
+        log_index=0,
+        is_pending=False,
+    )
+
+    expected_keys = [
+        "type",
+        "logIndex",
+        "transactionIndex",
+        "transactionHash",
+        "blockHash",
+        "blockNumber",
+        "address",
+        "data",
+        "topics",
+    ]
+
+    assert sorted(list(serialized_log.keys())) == sorted(expected_keys)
+
+
+def test_serialize_block_withdrawals_returns_camel_case_keys(
+    withdrawals: Tuple[FakeWithdrawal, ...],
+) -> None:
+    block = FakeBlock(withdrawals=withdrawals)
+
+    expected_keys = [
+        "index",
+        "validatorIndex",
+        "address",
+        "amount",
+    ]
+
+    serialized_block_withdrawals = serialize_block_withdrawals(block=block)
+
+    for withdrawal in serialized_block_withdrawals:
+        assert sorted(list(withdrawal.keys())) == sorted(expected_keys)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,14 @@
+"""Constants used in the validation tests."""
+
+ZERO_32BYTES = b"\x00" * 32
+ZERO_8BYTES = b"\x00" * 8
+ZERO_ADDRESS = b"\x00" * 20
+
+
+ADDRESS_A = b"\x00" * 19 + b"\x01"
+TOPIC_A = b"\x00" * 31 + b"\x01"
+TOPIC_B = b"\x00" * 31 + b"\x02"
+HASH32_AS_TEXT = "\x00" * 32
+HASH31 = b"\x00" * 31
+
+DEFAULT_GAS_LIMIT = 21000

--- a/tests/core/normalization/test_default_outbound_normalization.py
+++ b/tests/core/normalization/test_default_outbound_normalization.py
@@ -1,11 +1,129 @@
+from typing import (
+    Any,
+)
+
 import pytest
 
 from eth_tester.normalization import (
     DefaultNormalizer,
 )
 from tests.utils import (
+    make_blob_txn,
+    make_block,
+    make_log,
     make_receipt,
+    make_withdrawal,
 )
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (b"\x01" * 20, f"0x{'01' * 20}"),
+        (f"0x{'01' * 20}", f"0x{'01' * 20}"),
+        (b"\x01" * 32, None),
+        (b"\x01" * 21, None),
+        (b"\x01" * 19, None),
+        (b"\x01" * 0, None),
+        (b"\x01" * 1, None),
+    ),
+)
+def test_outbound_account_normalization(value: Any, expected: Any) -> None:
+    if expected:
+        assert DefaultNormalizer.normalize_outbound_account(value) == expected
+    else:
+        with pytest.raises(ValueError):
+            DefaultNormalizer.normalize_outbound_account(value) == expected
+
+
+def test_outbound_block_normalization() -> None:
+    block = make_block()
+
+    block["number"] = 1
+    block["hash"] = b"\x01" * 32
+    block["coinbase"] = b"\x01" * 20
+    block["logsBloom"] = 1
+    block["withdrawals"] = [
+        make_withdrawal(
+            index=0,
+            validator_index=0,
+            amount=0,
+            address=b"\x01" * 20,
+        )
+    ]
+
+    normalized_block = DefaultNormalizer.normalize_outbound_block(block)
+
+    assert normalized_block["number"] == 1
+    assert normalized_block["hash"] == f"0x{'01' * 32}"
+    assert normalized_block["coinbase"] == f"0x{'01' * 20}"
+    assert normalized_block["logsBloom"] == 1
+    assert normalized_block["withdrawals"] == [
+        {
+            "index": 0,
+            "validatorIndex": 0,
+            "amount": 0,
+            "address": f"0x{'01' * 20}",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (b"\x01" * 32, f"0x{'01' * 32}"),
+        (
+            f"0x{'01' * 2}",
+            "0x307830313031",
+        ),
+        ("0x01", "0x30783031"),
+        (b"\x01" * 20, "0x0101010101010101010101010101010101010101"),
+        (b"\x01", "0x01"),
+    ),
+)
+def test_outbound_block_hash_normalization(value: Any, expected: Any) -> None:
+    normalized_block_hash = DefaultNormalizer.normalize_outbound_block_hash(value)
+
+    assert normalized_block_hash == expected
+
+
+def test_outbound_log_entry_normalization() -> None:
+    log_entry = make_log()
+
+    log_entry["address"] = b"\x01" * 20
+    log_entry["data"] = b"\x01" * 32
+    log_entry["blockHash"] = b"\x01" * 32
+
+    normalized_log_entry = DefaultNormalizer.normalize_outbound_log_entry(log_entry)
+
+    assert normalized_log_entry["address"] == f"0x{'01' * 20}"
+    assert normalized_log_entry["data"] == f"0x{'01' * 32}"
+    assert normalized_log_entry["blockHash"] == f"0x{'01' * 32}"
+
+
+def test_outbound_transaction_normalization() -> None:
+    transaction = make_blob_txn()
+
+    transaction["from"] = b"\x01" * 20
+    transaction["data"] = b""
+    transaction["accessList"] = [(b"\x01" * 20, (1, 2, 3))]
+
+    normalized_transaction = DefaultNormalizer.normalize_outbound_transaction(
+        transaction
+    )
+
+    assert normalized_transaction["from"] == f"0x{'01' * 20}"
+    assert normalized_transaction["data"] == "0x"
+    assert normalized_transaction["accessList"] == (
+        {
+            "address": f"0x{'01' * 20}",
+            "storageKeys": (
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000000000000000000000000000002",
+                "0x0000000000000000000000000000000000000000000000000000000000000003",
+            ),
+        },
+    )
 
 
 @pytest.mark.parametrize(
@@ -16,19 +134,19 @@ from tests.utils import (
     ),
 )
 def test_outbound_receipt_contract_address_status_based_normalization(
-    status,
-    contract_address,
-    expected,
-):
+    status: Any,
+    contract_address: Any,
+    expected: Any,
+) -> None:
     receipt = make_receipt(status=status, contract_address=contract_address)
 
     assert receipt["status"] == status
-    assert receipt["contract_address"] == contract_address
+    assert receipt["contractAddress"] == contract_address
 
     normalized_receipt = DefaultNormalizer.normalize_outbound_receipt(receipt)
 
     assert normalized_receipt["status"] == status
-    assert normalized_receipt["contract_address"] == expected
+    assert normalized_receipt["contractAddress"] == expected
 
 
 @pytest.mark.parametrize(
@@ -37,7 +155,13 @@ def test_outbound_receipt_contract_address_status_based_normalization(
         (0, f"0x{'00'*32}"),
         (1, f"0x{'00'*31}01"),
         (2, f"0x{'00'*31}02"),
+        (None, None),
+        ("invalid-value", None),
     ),
 )
-def test_outbound_storage_normalization(value, expected):
-    assert DefaultNormalizer.normalize_outbound_storage(value) == expected
+def test_outbound_storage_normalization(value: Any, expected: Any) -> None:
+    if expected:
+        assert DefaultNormalizer.normalize_outbound_storage(value) == expected
+    else:
+        with pytest.raises(AttributeError):
+            DefaultNormalizer.normalize_outbound_storage(value)

--- a/tests/core/normalization/test_default_outbound_normalization.py
+++ b/tests/core/normalization/test_default_outbound_normalization.py
@@ -20,19 +20,25 @@ from tests.utils import (
     (
         (b"\x01" * 20, f"0x{'01' * 20}"),
         (f"0x{'01' * 20}", f"0x{'01' * 20}"),
-        (b"\x01" * 32, None),
-        (b"\x01" * 21, None),
-        (b"\x01" * 19, None),
-        (b"\x01" * 0, None),
-        (b"\x01" * 1, None),
     ),
 )
 def test_outbound_account_normalization(value: Any, expected: Any) -> None:
-    if expected:
-        assert DefaultNormalizer.normalize_outbound_account(value) == expected
-    else:
-        with pytest.raises(ValueError):
-            DefaultNormalizer.normalize_outbound_account(value)
+    assert DefaultNormalizer.normalize_outbound_account(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        b"\x01" * 32,
+        b"\x01" * 21,
+        b"\x01" * 19,
+        b"\x01" * 0,
+        b"\x01" * 1,
+    ),
+)
+def test_outbound_account_normalization_invalid(value: Any) -> None:
+    with pytest.raises(ValueError):
+        DefaultNormalizer.normalize_outbound_account(value)
 
 
 def test_outbound_block_normalization() -> None:
@@ -154,13 +160,21 @@ def test_outbound_receipt_contract_address_status_based_normalization(
         (0, f"0x{'00'*32}"),
         (1, f"0x{'00'*31}01"),
         (2, f"0x{'00'*31}02"),
-        (None, None),
-        ("invalid-value", None),
     ),
 )
 def test_outbound_storage_normalization(value: Any, expected: Any) -> None:
-    if expected:
-        assert DefaultNormalizer.normalize_outbound_storage(value) == expected
-    else:
-        with pytest.raises(AttributeError):
-            DefaultNormalizer.normalize_outbound_storage(value)
+    assert DefaultNormalizer.normalize_outbound_storage(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        b"\x01" * 32,
+        b"\x01" * 31,
+        None,
+        "invalid-value",
+    ),
+)
+def test_outbound_storage_normalization_invalid(value: Any) -> None:
+    with pytest.raises(AttributeError):
+        DefaultNormalizer.normalize_outbound_storage(value)

--- a/tests/core/normalization/test_default_outbound_normalization.py
+++ b/tests/core/normalization/test_default_outbound_normalization.py
@@ -1,8 +1,7 @@
+import pytest
 from typing import (
     Any,
 )
-
-import pytest
 
 from eth_tester.normalization import (
     DefaultNormalizer,
@@ -33,7 +32,7 @@ def test_outbound_account_normalization(value: Any, expected: Any) -> None:
         assert DefaultNormalizer.normalize_outbound_account(value) == expected
     else:
         with pytest.raises(ValueError):
-            DefaultNormalizer.normalize_outbound_account(value) == expected
+            DefaultNormalizer.normalize_outbound_account(value)
 
 
 def test_outbound_block_normalization() -> None:

--- a/tests/core/validation/conftest.py
+++ b/tests/core/validation/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from eth_tester.validation import (
+    DefaultValidator,
+)
+
+
+@pytest.fixture
+def validator() -> DefaultValidator:
+    """
+    Fixture to provide a DefaultValidator instance for testing.
+    This fixture is used to validate various data structures and
+    transactions.
+    """
+    _validator = DefaultValidator()
+    return _validator

--- a/tests/core/validation/test_inbound_validation.py
+++ b/tests/core/validation/test_inbound_validation.py
@@ -1,5 +1,4 @@
 import pytest
-
 from eth_utils import (
     decode_hex,
     encode_hex,
@@ -18,12 +17,6 @@ from eth_tester.validation.inbound import (
 from tests.utils import (
     yield_key_value_if_value_not_none,
 )
-
-
-@pytest.fixture
-def validator():
-    _validator = DefaultValidator()
-    return _validator
 
 
 @pytest.mark.parametrize(

--- a/tests/core/validation/test_inbound_validation.py
+++ b/tests/core/validation/test_inbound_validation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from eth_utils import (
     decode_hex,
     encode_hex,

--- a/tests/core/validation/test_outbound_validation.py
+++ b/tests/core/validation/test_outbound_validation.py
@@ -1,5 +1,12 @@
-import pytest
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
 
+import pytest
 from eth_utils import (
     encode_hex,
 )
@@ -8,82 +15,62 @@ from toolz import (
     merge,
 )
 
+from eth_tester.constants import (
+    ACCESS_LIST_TX_TYPE,
+    BLOB_TX_TYPE,
+    DYNAMIC_FEE_TX_TYPE,
+    LEGACY_TX_TYPE,
+)
 from eth_tester.exceptions import (
     ValidationError,
 )
 from eth_tester.validation import (
     DefaultValidator,
 )
+from tests.constants import (
+    ADDRESS_A,
+    DEFAULT_GAS_LIMIT,
+    HASH31,
+    HASH32_AS_TEXT,
+    TOPIC_A,
+    TOPIC_B,
+    ZERO_8BYTES,
+    ZERO_32BYTES,
+    ZERO_ADDRESS,
+)
 from tests.utils import (
     make_receipt,
 )
 
 
-@pytest.fixture
-def validator():
-    _validator = DefaultValidator()
-    return _validator
-
-
-@pytest.mark.parametrize(
-    "block_hash,is_valid",
-    (
-        (1, False),
-        (True, False),
-        (b"\x00" * 32, True),
-        (b"\xff" * 32, True),
-        ("\x00" * 32, False),
-        (encode_hex(b"\x00" * 32), False),
-    ),
-)
-def test_block_hash_output_validation(validator, block_hash, is_valid):
-    if is_valid:
-        validator.validate_outbound_block_hash(block_hash)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_block_hash(block_hash)
-
-
-ZERO_32BYTES = b"\x00" * 32
-ZERO_8BYTES = b"\x00" * 8
-ZERO_ADDRESS = b"\x00" * 20
-
-
-ADDRESS_A = b"\x00" * 19 + b"\x01"
-TOPIC_A = b"\x00" * 31 + b"\x01"
-TOPIC_B = b"\x00" * 31 + b"\x02"
-HASH32_AS_TEXT = "\x00" * 32
-HASH31 = b"\x00" * 31
-
-
 def _make_legacy_txn(
-    hash=ZERO_32BYTES,
-    nonce=0,
-    block_hash=ZERO_32BYTES,
-    block_number=0,
-    transaction_index=0,
-    _from=ZERO_ADDRESS,
-    to=ZERO_ADDRESS,
-    value=0,
-    gas=21000,
-    gas_price=1,
-    data=b"",
-    v=0,
-    r=0,
-    s=0,
-):
+    hash: Any = ZERO_32BYTES,
+    nonce: Any = 0,
+    block_hash: Optional[Any] = ZERO_32BYTES,
+    block_number: Optional[Any] = 0,
+    transaction_index: Optional[int] = 0,
+    _from: Any = ZERO_ADDRESS,
+    to: Any = ZERO_ADDRESS,
+    value: Any = 0,
+    gas: Any = DEFAULT_GAS_LIMIT,
+    gas_price: Any = 1,
+    data: Any = b"",
+    v: Any = 0,
+    r: Any = 0,
+    s: Any = 0,
+) -> Dict[str, Any]:
     return {
-        "type": "0x0",
+        "type": LEGACY_TX_TYPE,
         "hash": hash,
         "nonce": nonce,
-        "block_hash": block_hash,
-        "block_number": block_number,
-        "transaction_index": transaction_index,
+        "blockHash": block_hash,
+        "blockNumber": block_number,
+        "transactionIndex": transaction_index,
         "from": _from,
         "to": to,
         "value": value,
         "gas": gas,
-        "gas_price": gas_price,
+        "gasPrice": gas_price,
         "data": data,
         "s": s,
         "r": r,
@@ -92,19 +79,21 @@ def _make_legacy_txn(
 
 
 def _make_access_list_txn(
-    chain_id=131277322940537,
-    access_list=(),
-    **kwargs,
-):
+    chain_id: Any = 131277322940537,
+    access_list: Tuple[Any, ...] = (),
+    **kwargs: Any,
+) -> Dict[str, Any]:
     legacy_kwargs = dissoc(dict(**kwargs), "chain_id", "access_list")
-    return merge(
-        _make_legacy_txn(**legacy_kwargs),
-        {
-            "type": "0x1",
-            "chain_id": chain_id,
-            "access_list": list(access_list),
-            "y_parity": legacy_kwargs.get("v", 0),
-        },
+    return dict(
+        merge(
+            _make_legacy_txn(**legacy_kwargs),
+            {
+                "type": ACCESS_LIST_TX_TYPE,
+                "chainId": chain_id,
+                "accessList": list(access_list),
+                "yParity": legacy_kwargs.get("v", 0),
+            },
+        )
     )
 
 
@@ -114,146 +103,483 @@ def _make_access_list_txn(
 #  transactions and we can get rid of this behavior.
 #  https://github.com/ethereum/execution-specs/pull/251
 def _make_dynamic_fee_txn(
-    chain_id=131277322940537,
-    max_fee_per_gas=2000000000,
-    max_priority_fee_per_gas=1000000000,
-    access_list=(),
-    **kwargs,
-):
+    chain_id: Any = 131277322940537,
+    max_fee_per_gas: Any = 2000000000,
+    max_priority_fee_per_gas: Any = 1000000000,
+    access_list: Tuple[Any, ...] = (),
+    **kwargs: Any,
+) -> Dict[str, Any]:
     legacy_kwargs = dissoc(
         dict(**kwargs),
-        "chain_id",
-        "max_fee_per_gas",
-        "max_priority_fee_per_gas",
-        "access_list",
+        "chainId",
+        "maxFeePerGas",
+        "maxPriorityFeePerGas",
+        "accessList",
     )
-    return merge(
-        _make_access_list_txn(
-            chain_id=chain_id, access_list=access_list, **legacy_kwargs
-        ),
-        {
-            "type": "0x2",
-            "max_fee_per_gas": max_fee_per_gas,
-            "max_priority_fee_per_gas": max_priority_fee_per_gas,
-        },
+    return dict(
+        merge(
+            _make_access_list_txn(
+                chain_id=chain_id, access_list=access_list, **legacy_kwargs
+            ),
+            {
+                "type": DYNAMIC_FEE_TX_TYPE,
+                "maxFeePerGas": max_fee_per_gas,
+                "maxPriorityFeePerGas": max_priority_fee_per_gas,
+            },
+        )
     )
+
+
+def _make_blob_txn(
+    chain_id: Any = 131277322940537,
+    max_fee_per_gas: Any = 2000000000,
+    max_priority_fee_per_gas: Any = 1000000000,
+    access_list: Tuple[Any, ...] = (),
+    max_fee_per_blob_gas: Any = 1000000000,
+    blob_versioned_hashes: Tuple[Any, ...] = (),
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    legacy_kwargs = dissoc(
+        dict(**kwargs),
+        "chainId",
+        "maxFeePerGas",
+        "maxPriorityFeePerGas",
+        "accessList",
+        "maxFeePerBlobGas",
+        "blobVersionedHashes",
+    )
+    return dict(
+        merge(
+            _make_dynamic_fee_txn(
+                chain_id=chain_id,
+                access_list=access_list,
+                max_fee_per_gas=max_fee_per_gas,
+                max_priority_fee_per_gas=max_priority_fee_per_gas,
+                **legacy_kwargs,
+            ),
+            {
+                "type": BLOB_TX_TYPE,
+                "maxFeePerBlobGas": max_fee_per_blob_gas,
+                "blobVersionedHashes": list(blob_versioned_hashes),
+            },
+        )
+    )
+
+
+def _make_log(
+    _type: Any = "mined",
+    log_index: Any = 0,
+    transaction_index: Any = 0,
+    transaction_hash: Any = ZERO_32BYTES,
+    block_hash: Any = ZERO_32BYTES,
+    block_number: Any = 0,
+    address: Any = ZERO_ADDRESS,
+    data: Any = b"",
+    topics: Optional[List[Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "type": _type,
+        "logIndex": log_index,
+        "transactionIndex": transaction_index,
+        "transactionHash": transaction_hash,
+        "blockHash": block_hash,
+        "blockNumber": block_number,
+        "address": address,
+        "data": data,
+        "topics": topics or [],
+    }
+
+
+def _make_block(
+    number: Any = 0,
+    hash: Any = ZERO_32BYTES,
+    parent_hash: Any = ZERO_32BYTES,
+    nonce: Any = ZERO_8BYTES,
+    sha3_uncles: Any = ZERO_32BYTES,
+    logs_bloom: Any = 0,
+    transactions_root: Any = ZERO_32BYTES,
+    receipts_root: Any = ZERO_32BYTES,
+    state_root: Any = ZERO_32BYTES,
+    coinbase: Any = ZERO_ADDRESS,
+    difficulty: Any = 0,
+    mix_hash: Any = ZERO_32BYTES,
+    total_difficulty: Any = 0,
+    size: Any = 0,
+    extra_data: Any = ZERO_32BYTES,
+    gas_limit: Any = 30029122,  # gas limit at London fork block 12965000 on mainnet
+    gas_used: Any = 21000,
+    timestamp: Any = 4000000,
+    transactions: Optional[List[Any]] = None,
+    uncles: Optional[List[Any]] = None,
+    base_fee_per_gas: Any = 1000000000,
+    withdrawals: Optional[List[Any]] = None,
+    withdrawals_root: Any = ZERO_32BYTES,
+) -> Dict[str, Any]:
+    block = {
+        "number": number,
+        "hash": hash,
+        "parentHash": parent_hash,
+        "nonce": nonce,
+        "sha3Uncles": sha3_uncles,
+        "logsBloom": logs_bloom,
+        "transactionsRoot": transactions_root,
+        "receiptsRoot": receipts_root,
+        "stateRoot": state_root,
+        "coinbase": coinbase,
+        "difficulty": difficulty,
+        "mixHash": mix_hash,
+        "totalDifficulty": total_difficulty,
+        "size": size,
+        "extraData": extra_data,
+        "gasLimit": gas_limit,
+        "gasUsed": gas_used,
+        "timestamp": timestamp,
+        "transactions": transactions or [],
+        "uncles": uncles or [],
+        "baseFeePerGas": base_fee_per_gas,
+        "withdrawals": withdrawals or [],
+        "withdrawalsRoot": withdrawals_root,
+    }
+    return block
+
+
+def _make_withdrawal(
+    index: Any = 2**64 - 1,
+    validator_index: Any = 2**64 - 1,
+    address: Any = ZERO_ADDRESS,
+    amount: Any = 2**64 - 1,
+) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "validatorIndex": validator_index,
+        "address": address,
+        "amount": amount,
+    }
+
+
+@pytest.mark.parametrize(
+    "block_hash,is_valid",
+    (
+        pytest.param(ZERO_32BYTES, True, id="valid_bytes_all_zero"),
+        pytest.param(b"\xff" * 32, True, id="valid_bytes_all_ff"),
+        pytest.param(b"\x00", False, id="invalid_bytes_short"),
+        pytest.param("\x00" * 32, False, id="invalid_str"),
+        pytest.param(encode_hex(ZERO_32BYTES), False, id="invalid_hex"),
+        pytest.param(1, False, id="invalid_int"),
+        pytest.param(True, False, id="invalid_bool"),
+    ),
+)
+def test_block_hash_output_validation(
+    validator: DefaultValidator, block_hash: Any, is_valid: bool
+) -> None:
+    if is_valid:
+        validator.validate_outbound_block_hash(block_hash)
+    else:
+        with pytest.raises(ValidationError):
+            validator.validate_outbound_block_hash(block_hash)
+
+
+@pytest.mark.parametrize(
+    "value,is_valid",
+    [(ZERO_32BYTES, True), (ZERO_32BYTES + b"\x00", False), (b"0x", False), (1, False)],
+    ids=["valid", "invalid_too_long", "invalid_hex", "invalid_int"],
+)
+def test_validate_outbound_transaction_hash(
+    validator: DefaultValidator,
+    value: Any,
+    is_valid: bool,
+) -> None:
+    if is_valid:
+        validator.validate_outbound_transaction_hash(value)
+    else:
+        with pytest.raises(ValidationError):
+            validator.validate_outbound_transaction_hash(value)
 
 
 @pytest.mark.parametrize(
     "transaction,is_valid",
     (
-        (_make_legacy_txn(), True),
-        (_make_access_list_txn(), True),
-        (_make_dynamic_fee_txn(), True),
-        (_make_legacy_txn(hash=HASH32_AS_TEXT), False),
-        (_make_legacy_txn(hash=HASH31), False),
-        (_make_legacy_txn(nonce=-1), False),
-        (_make_legacy_txn(nonce=1.0), False),
-        (_make_legacy_txn(nonce=True), False),
-        (_make_legacy_txn(value=-1), False),
-        (_make_legacy_txn(value=1.0), False),
-        (_make_legacy_txn(value=True), False),
-        (_make_legacy_txn(block_number=-1), False),
-        (_make_legacy_txn(block_number=1.0), False),
-        (_make_legacy_txn(block_number=True), False),
-        (_make_legacy_txn(gas=-1), False),
-        (_make_legacy_txn(gas=1.0), False),
-        (_make_legacy_txn(gas=True), False),
-        (_make_legacy_txn(gas_price=-1), False),
-        (_make_legacy_txn(gas_price=1.0), False),
-        (_make_legacy_txn(gas_price=True), False),
-        (_make_legacy_txn(data=""), False),
-        (_make_legacy_txn(data="0x"), False),
-        (_make_legacy_txn(block_hash=HASH32_AS_TEXT), False),
-        (_make_legacy_txn(block_hash=HASH31), False),
-        (
+        pytest.param(_make_legacy_txn(), True, id="valid_legacy_txn"),
+        pytest.param(_make_access_list_txn(), True, id="valid_access_list_txn"),
+        pytest.param(_make_dynamic_fee_txn(), True, id="valid_dynamic_fee_txn"),
+        pytest.param(_make_blob_txn(), True, id="valid_blob_txn"),
+        pytest.param(
+            _make_legacy_txn(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"
+        ),
+        pytest.param(_make_legacy_txn(hash=HASH31), False, id="invalid_short_hash"),
+        pytest.param(_make_legacy_txn(nonce=-1), False, id="invalid_negative_nonce"),
+        pytest.param(_make_legacy_txn(nonce=1.0), False, id="invalid_float_nonce"),
+        pytest.param(_make_legacy_txn(nonce=True), False, id="invalid_bool_nonce"),
+        pytest.param(_make_legacy_txn(value=-1), False, id="invalid_negative_value"),
+        pytest.param(_make_legacy_txn(value=1.0), False, id="invalid_float_value"),
+        pytest.param(_make_legacy_txn(value=True), False, id="invalid_bool_value"),
+        pytest.param(
+            _make_legacy_txn(block_number=-1), False, id="invalid_negative_block_number"
+        ),
+        pytest.param(
+            _make_legacy_txn(block_number=1.0), False, id="invalid_float_block_number"
+        ),
+        pytest.param(
+            _make_legacy_txn(block_number=True), False, id="invalid_bool_block_number"
+        ),
+        pytest.param(_make_legacy_txn(gas=-1), False, id="invalid_negative_gas"),
+        pytest.param(_make_legacy_txn(gas=1.0), False, id="invalid_float_gas"),
+        pytest.param(_make_legacy_txn(gas=True), False, id="invalid_bool_gas"),
+        pytest.param(
+            _make_legacy_txn(gas_price=-1), False, id="invalid_negative_gas_price"
+        ),
+        pytest.param(
+            _make_legacy_txn(gas_price=1.0), False, id="invalid_float_gas_price"
+        ),
+        pytest.param(
+            _make_legacy_txn(gas_price=True), False, id="invalid_bool_gas_price"
+        ),
+        pytest.param(_make_legacy_txn(data=""), False, id="invalid_empty_string_data"),
+        pytest.param(_make_legacy_txn(data="0x"), False, id="invalid_0x_string_data"),
+        pytest.param(
+            _make_legacy_txn(block_hash=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_block_hash",
+        ),
+        pytest.param(
+            _make_legacy_txn(block_hash=HASH31), False, id="invalid_short_block_hash"
+        ),
+        pytest.param(
             _make_legacy_txn(
                 transaction_index=None, block_hash=None, block_number=None
             ),
             True,
+            id="valid_pending_legacy_txn",
         ),
-        (
+        pytest.param(
             _make_access_list_txn(
                 transaction_index=None,
                 block_hash=None,
                 block_number=None,
             ),
             True,
+            id="valid_pending_access_list_txn",
         ),
-        (
+        pytest.param(
             _make_dynamic_fee_txn(
                 transaction_index=None,
                 block_hash=None,
                 block_number=None,
             ),
             True,
+            id="valid_pending_dynamic_fee_txn",
         ),
-        (_make_access_list_txn(chain_id="1"), False),
-        (_make_dynamic_fee_txn(chain_id="1"), False),
-        (_make_access_list_txn(chain_id=-1), False),
-        (_make_dynamic_fee_txn(chain_id=-1), False),
-        (_make_access_list_txn(chain_id=None), False),
-        (_make_dynamic_fee_txn(chain_id=None), False),
-        (_make_legacy_txn(v=0), True),
-        (_make_dynamic_fee_txn(v=0), True),
-        (_make_access_list_txn(v=0), True),
-        (_make_legacy_txn(v=1), True),
-        (_make_dynamic_fee_txn(v=1), True),
-        (_make_access_list_txn(v=1), True),
-        (_make_legacy_txn(v=27), True),
-        (_make_access_list_txn(v=27), False),
-        (_make_dynamic_fee_txn(v=27), False),
-        (_make_dynamic_fee_txn(max_fee_per_gas=1.0), False),
-        (_make_dynamic_fee_txn(max_priority_fee_per_gas=1.0), False),
-        (_make_dynamic_fee_txn(max_fee_per_gas="1"), False),
-        (_make_dynamic_fee_txn(max_priority_fee_per_gas="1"), False),
-        (
+        pytest.param(
+            _make_blob_txn(
+                transaction_index=None,
+                block_hash=None,
+                block_number=None,
+            ),
+            True,
+            id="valid_pending_blob_txn",
+        ),
+        pytest.param(
+            _make_access_list_txn(chain_id="1"),
+            False,
+            id="invalid_string_chain_id_access_list",
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(chain_id="1"),
+            False,
+            id="invalid_string_chain_id_dynamic_fee",
+        ),
+        pytest.param(
+            _make_blob_txn(chain_id="1"), False, id="invalid_string_chain_id_blob"
+        ),
+        pytest.param(
+            _make_access_list_txn(chain_id=-1),
+            False,
+            id="invalid_negative_chain_id_access_list",
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(chain_id=-1),
+            False,
+            id="invalid_negative_chain_id_dynamic_fee",
+        ),
+        pytest.param(
+            _make_blob_txn(chain_id=-1), False, id="invalid_negative_chain_id_blob"
+        ),
+        pytest.param(
+            _make_access_list_txn(chain_id=None),
+            False,
+            id="invalid_none_chain_id_access_list",
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(chain_id=None),
+            False,
+            id="invalid_none_chain_id_dynamic_fee",
+        ),
+        pytest.param(
+            _make_blob_txn(chain_id=None), False, id="invalid_none_chain_id_blob"
+        ),
+        pytest.param(_make_legacy_txn(v=0), True, id="valid_v_0_legacy"),
+        pytest.param(_make_dynamic_fee_txn(v=0), True, id="valid_v_0_dynamic_fee"),
+        pytest.param(_make_access_list_txn(v=0), True, id="valid_v_0_access_list"),
+        pytest.param(_make_blob_txn(v=0), True, id="valid_v_0_blob"),
+        pytest.param(_make_legacy_txn(v=1), True, id="valid_v_1_legacy"),
+        pytest.param(_make_dynamic_fee_txn(v=1), True, id="valid_v_1_dynamic_fee"),
+        pytest.param(_make_access_list_txn(v=1), True, id="valid_v_1_access_list"),
+        pytest.param(_make_blob_txn(v=1), True, id="valid_v_1_blob"),
+        pytest.param(_make_legacy_txn(v=27), True, id="valid_v_27_legacy"),
+        pytest.param(_make_access_list_txn(v=27), False, id="invalid_v_27_access_list"),
+        pytest.param(_make_dynamic_fee_txn(v=27), False, id="invalid_v_27_dynamic_fee"),
+        pytest.param(_make_blob_txn(v=27), False, id="invalid_v_27_blob"),
+        pytest.param(
+            _make_dynamic_fee_txn(max_fee_per_gas=1.0),
+            False,
+            id="invalid_float_max_fee_per_gas",
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(max_priority_fee_per_gas=1.0),
+            False,
+            id="invalid_float_max_priority_fee",
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(max_fee_per_gas="1"),
+            False,
+            id="invalid_string_max_fee_per_gas",
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(max_priority_fee_per_gas="1"),
+            False,
+            id="invalid_string_max_priority_fee",
+        ),
+        pytest.param(
+            _make_blob_txn(max_fee_per_blob_gas=1.0),
+            False,
+            id="invalid_float_max_fee_per_blob_gas",
+        ),
+        pytest.param(
+            _make_blob_txn(max_fee_per_blob_gas="1"),
+            False,
+            id="invalid_string_max_fee_per_blob_gas",
+        ),
+        pytest.param(_make_blob_txn(blob_versioned_hashes=""), True, id="valid_string_blob_hashes"),  # type: ignore[arg-type]
+        pytest.param(
+            _make_blob_txn(blob_versioned_hashes=()), True, id="valid_empty_blob_hashes"
+        ),
+        pytest.param(
+            _make_blob_txn(blob_versioned_hashes=("",)),
+            False,
+            id="invalid_empty_string_in_blob_hashes",
+        ),
+        pytest.param(
+            _make_blob_txn(blob_versioned_hashes=(ZERO_32BYTES,)),
+            True,
+            id="valid_bytes32_blob_hash",
+        ),
+        pytest.param(
+            _make_blob_txn(blob_versioned_hashes=(b"\x00" * 31,)),
+            False,
+            id="invalid_bytes31_blob_hash",
+        ),
+        pytest.param(
+            _make_blob_txn(blob_versioned_hashes=(b"\x00",)),
+            False,
+            id="invalid_bytes1_blob_hash",
+        ),
+        pytest.param(
             _make_access_list_txn(
                 access_list=((b"\xf0" * 20, (0, 2)),),
             ),
             True,
+            id="valid_access_list_with_storage_keys",
         ),
-        (
+        pytest.param(
             _make_dynamic_fee_txn(
                 access_list=((b"\xef" * 20, (1, 2, 3, 4)),),
             ),
             True,
+            id="valid_dynamic_fee_with_storage_keys",
         ),
-        (_make_access_list_txn(access_list=()), True),
-        (_make_dynamic_fee_txn(access_list=()), True),
-        (
+        pytest.param(
+            _make_blob_txn(
+                access_list=((b"\xef" * 20, (1, 2, 3, 4)),),
+            ),
+            True,
+            id="valid_blob_with_storage_keys",
+        ),
+        pytest.param(
+            _make_access_list_txn(access_list=()), True, id="valid_empty_access_list"
+        ),
+        pytest.param(
+            _make_dynamic_fee_txn(access_list=()),
+            True,
+            id="valid_empty_dynamic_fee_access_list",
+        ),
+        pytest.param(
+            _make_blob_txn(access_list=()), True, id="valid_empty_blob_access_list"
+        ),
+        pytest.param(
             _make_access_list_txn(
                 access_list=((b"\xf0" * 19, (0, 2)),),
             ),
             False,
+            id="invalid_short_address_in_access_list",
         ),
-        (
+        pytest.param(
             _make_dynamic_fee_txn(
                 access_list=((b"\xf0" * 19, ()),),
             ),
             False,
+            id="invalid_short_address_with_empty_storage_keys",
         ),
-        (
+        pytest.param(
+            _make_blob_txn(
+                access_list=((b"\xf0" * 19, ()),),
+            ),
+            False,
+            id="invalid_short_address_in_blob_access_list",
+        ),
+        pytest.param(
             _make_access_list_txn(
                 access_list=((b"\xf0" * 20, ("0", 2)),),
             ),
             False,
+            id="invalid_string_storage_key",
         ),
-        (
+        pytest.param(
             _make_dynamic_fee_txn(
                 access_list=((b"\xf0" * 20, (b"", 1)),),
             ),
             False,
+            id="invalid_empty_bytes_storage_key",
         ),
-        (
+        pytest.param(
+            _make_blob_txn(
+                access_list=((b"\xf0" * 20, (b"", 1)),),
+            ),
+            False,
+            id="invalid_empty_bytes_storage_key_in_blob",
+        ),
+        pytest.param(
             _make_dynamic_fee_txn(
                 access_list=(("", (1, 2)),),
             ),
             False,
+            id="invalid_empty_string_address_in_access_list",
+        ),
+        pytest.param(
+            _make_blob_txn(
+                access_list=(("", (1, 2)),),
+            ),
+            False,
+            id="invalid_empty_string_address_in_blob_access_list",
+        ),
+        pytest.param({}, False, id="invalid_empty_dict"),
+        pytest.param(
+            merge(_make_legacy_txn(), {"invalid-key": 1}), False, id="invalid_extra_key"
         ),
     ),
 )
-def test_transaction_output_validation(validator, transaction, is_valid):
+def test_transaction_output_validation(
+    validator: DefaultValidator, transaction: Any, is_valid: bool
+) -> None:
     if is_valid:
         validator.validate_outbound_transaction(transaction)
     else:
@@ -261,35 +587,11 @@ def test_transaction_output_validation(validator, transaction, is_valid):
             validator.validate_outbound_transaction(transaction)
 
 
-def _make_log(
-    _type="mined",
-    log_index=0,
-    transaction_index=0,
-    transaction_hash=ZERO_32BYTES,
-    block_hash=ZERO_32BYTES,
-    block_number=0,
-    address=ZERO_ADDRESS,
-    data=b"",
-    topics=None,
-):
-    return {
-        "type": _type,
-        "log_index": log_index,
-        "transaction_index": transaction_index,
-        "transaction_hash": transaction_hash,
-        "block_hash": block_hash,
-        "block_number": block_number,
-        "address": address,
-        "data": data,
-        "topics": topics or [],
-    }
-
-
 @pytest.mark.parametrize(
     "log_entry,is_valid",
     (
-        (_make_log(), True),
-        (
+        pytest.param(_make_log(), True, id="valid_standard_log"),
+        pytest.param(
             _make_log(
                 _type="pending",
                 transaction_index=None,
@@ -297,24 +599,67 @@ def _make_log(
                 block_number=None,
             ),
             True,
+            id="valid_pending_log",
         ),
-        (_make_log(_type="invalid-type"), False),
-        (_make_log(transaction_index=-1), False),
-        (_make_log(block_number=-1), False),
-        (_make_log(transaction_hash=HASH31), False),
-        (_make_log(transaction_hash=HASH32_AS_TEXT), False),
-        (_make_log(block_hash=HASH31), False),
-        (_make_log(block_hash=HASH32_AS_TEXT), False),
-        (_make_log(address=encode_hex(ADDRESS_A)), False),
-        (_make_log(data=""), False),
-        (_make_log(data=None), False),
-        (_make_log(topics=[HASH32_AS_TEXT]), False),
-        (_make_log(topics=[HASH31]), False),
-        (_make_log(topics=[TOPIC_A, TOPIC_B]), True),
-        (_make_log(address=ADDRESS_A), True),
+        pytest.param(
+            _make_log(
+                _type="mined",
+                transaction_index=None,
+                block_hash=None,
+                block_number=None,
+            ),
+            True,
+            id="valid_mined_log_with_nulls",
+        ),
+        pytest.param(_make_log(_type="invalid-type"), False, id="invalid_log_type"),
+        pytest.param(
+            _make_log(transaction_index=-1),
+            False,
+            id="invalid_negative_transaction_index",
+        ),
+        pytest.param(
+            _make_log(block_number=-1), False, id="invalid_negative_block_number"
+        ),
+        pytest.param(
+            _make_log(transaction_hash=HASH31),
+            False,
+            id="invalid_short_transaction_hash",
+        ),
+        pytest.param(
+            _make_log(transaction_hash=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_transaction_hash",
+        ),
+        pytest.param(
+            _make_log(block_hash=HASH31), False, id="invalid_short_block_hash"
+        ),
+        pytest.param(
+            _make_log(block_hash=HASH32_AS_TEXT), False, id="invalid_text_block_hash"
+        ),
+        pytest.param(
+            _make_log(address=encode_hex(ADDRESS_A)), False, id="invalid_hex_address"
+        ),
+        pytest.param(_make_log(data=""), False, id="invalid_empty_string_data"),
+        pytest.param(_make_log(data=None), False, id="invalid_none_data"),
+        pytest.param(
+            _make_log(topics=[HASH32_AS_TEXT]), False, id="invalid_text_topic"
+        ),
+        pytest.param(_make_log(topics=[HASH31]), False, id="invalid_short_topic"),
+        pytest.param(
+            _make_log(topics=[TOPIC_A, TOPIC_B]), True, id="valid_multiple_topics"
+        ),
+        pytest.param(
+            _make_log(topics="invalid-topics"), False, id="invalid_string_topics"  # type: ignore[arg-type]
+        ),
+        pytest.param(_make_log(address=ADDRESS_A), True, id="valid_address"),
+        pytest.param(
+            merge(_make_log(), {"invalid-key": 1}), False, id="invalid_extra_key"
+        ),
     ),
 )
-def test_log_entry_output_validation(validator, log_entry, is_valid):
+def test_log_entry_output_validation(
+    validator: DefaultValidator, log_entry: Any, is_valid: bool
+) -> None:
     if is_valid:
         validator.validate_outbound_log_entry(log_entry)
     else:
@@ -325,48 +670,163 @@ def test_log_entry_output_validation(validator, log_entry, is_valid):
 @pytest.mark.parametrize(
     "receipt,is_valid",
     (
-        (make_receipt(), True),
-        (make_receipt(transaction_hash=HASH32_AS_TEXT), False),
-        (make_receipt(transaction_hash=HASH31), False),
-        (make_receipt(block_hash=HASH32_AS_TEXT), False),
-        (make_receipt(block_hash=HASH31), False),
-        (make_receipt(transaction_index=-1), False),
-        (make_receipt(transaction_index=1.0), False),
-        (make_receipt(transaction_index=True), False),
-        (make_receipt(block_number=-1), False),
-        (make_receipt(block_number=1.0), False),
-        (make_receipt(block_number=True), False),
-        (make_receipt(gas_used=-1), False),
-        (make_receipt(gas_used=1.0), False),
-        (make_receipt(gas_used=True), False),
-        (make_receipt(cumulative_gas_used=-1), False),
-        (make_receipt(cumulative_gas_used=1.0), False),
-        (make_receipt(cumulative_gas_used=True), False),
-        (make_receipt(contract_address=ZERO_ADDRESS), True),
-        (make_receipt(contract_address=encode_hex(ZERO_ADDRESS)), False),
-        (make_receipt(logs=[_make_log()]), True),
-        (make_receipt(logs=[_make_log(_type="invalid")]), False),
-        (make_receipt(_from=ADDRESS_A, to=ADDRESS_A), True),
-        (make_receipt(_from=ADDRESS_A, to=ZERO_ADDRESS), True),
-        (make_receipt(_from=encode_hex(ZERO_ADDRESS), to=ADDRESS_A), False),
-        (make_receipt(_from=ADDRESS_A, to=encode_hex(ZERO_ADDRESS)), False),
-        (make_receipt(status=0), True),
-        (make_receipt(status=1), True),
-        (make_receipt(status=2), False),
-        (make_receipt(status=-1), False),
-        (make_receipt(blob_gas_used=-1, blob_gas_price=-1), False),
-        (make_receipt(blob_gas_used=-1, blob_gas_price=0), False),
-        (make_receipt(blob_gas_used=0, blob_gas_price=-1), False),
-        (make_receipt(blob_gas_used=0, blob_gas_price=0), True),
-        (make_receipt(blob_gas_used=0, blob_gas_price=1), True),
-        (make_receipt(blob_gas_used=1, blob_gas_price=0), True),
-        (make_receipt(blob_gas_used=1, blob_gas_price=1), True),
-        (make_receipt(blob_gas_used=2, blob_gas_price=1), True),
-        (make_receipt(blob_gas_used=1, blob_gas_price=2), True),
-        (make_receipt(blob_gas_used=2, blob_gas_price=2), True),
+        pytest.param(make_receipt(), True, id="valid_standard_receipt"),
+        pytest.param(
+            make_receipt(transaction_hash=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_transaction_hash",
+        ),
+        pytest.param(
+            make_receipt(transaction_hash=HASH31),
+            False,
+            id="invalid_short_transaction_hash",
+        ),
+        pytest.param(
+            make_receipt(block_hash=HASH32_AS_TEXT), False, id="invalid_text_block_hash"
+        ),
+        pytest.param(
+            make_receipt(block_hash=HASH31), False, id="invalid_short_block_hash"
+        ),
+        pytest.param(
+            make_receipt(transaction_index=-1),
+            False,
+            id="invalid_negative_transaction_index",
+        ),
+        pytest.param(
+            make_receipt(transaction_index=1.0),
+            False,
+            id="invalid_float_transaction_index",
+        ),
+        pytest.param(
+            make_receipt(transaction_index=True),
+            False,
+            id="invalid_bool_transaction_index",
+        ),
+        pytest.param(
+            make_receipt(block_number=-1), False, id="invalid_negative_block_number"
+        ),
+        pytest.param(
+            make_receipt(block_number=1.0), False, id="invalid_float_block_number"
+        ),
+        pytest.param(
+            make_receipt(block_number=True), False, id="invalid_bool_block_number"
+        ),
+        pytest.param(make_receipt(gas_used=-1), False, id="invalid_negative_gas_used"),
+        pytest.param(make_receipt(gas_used=1.0), False, id="invalid_float_gas_used"),
+        pytest.param(make_receipt(gas_used=True), False, id="invalid_bool_gas_used"),
+        pytest.param(
+            make_receipt(cumulative_gas_used=-1),
+            False,
+            id="invalid_negative_cumulative_gas_used",
+        ),
+        pytest.param(
+            make_receipt(cumulative_gas_used=1.0),
+            False,
+            id="invalid_float_cumulative_gas_used",
+        ),
+        pytest.param(
+            make_receipt(cumulative_gas_used=True),
+            False,
+            id="invalid_bool_cumulative_gas_used",
+        ),
+        pytest.param(
+            make_receipt(contract_address=ZERO_ADDRESS),
+            True,
+            id="valid_contract_address",
+        ),
+        pytest.param(
+            make_receipt(contract_address=encode_hex(ZERO_ADDRESS)),
+            False,
+            id="invalid_hex_contract_address",
+        ),
+        pytest.param(make_receipt(logs=[_make_log()]), True, id="valid_logs"),
+        pytest.param(
+            make_receipt(logs=[_make_log(_type="invalid")]),
+            False,
+            id="invalid_log_type_in_logs",
+        ),
+        pytest.param(
+            make_receipt(_from=ADDRESS_A, to=ADDRESS_A),
+            True,
+            id="valid_from_to_same_address",
+        ),
+        pytest.param(
+            make_receipt(_from=ADDRESS_A, to=ZERO_ADDRESS),
+            True,
+            id="valid_from_to_different_address",
+        ),
+        pytest.param(
+            make_receipt(_from=encode_hex(ZERO_ADDRESS), to=ADDRESS_A),
+            False,
+            id="invalid_hex_from_address",
+        ),
+        pytest.param(
+            make_receipt(_from=ADDRESS_A, to=encode_hex(ZERO_ADDRESS)),
+            False,
+            id="invalid_hex_to_address",
+        ),
+        pytest.param(make_receipt(status=0), True, id="valid_status_0"),
+        pytest.param(make_receipt(status=1), True, id="valid_status_1"),
+        pytest.param(make_receipt(status=2), False, id="invalid_status_2"),
+        pytest.param(make_receipt(status=-1), False, id="invalid_negative_status"),
+        pytest.param(
+            make_receipt(blob_gas_used=-1, blob_gas_price=-1),
+            False,
+            id="invalid_negative_blob_gas_used_and_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=-1, blob_gas_price=0),
+            False,
+            id="invalid_negative_blob_gas_used",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=0, blob_gas_price=-1),
+            False,
+            id="invalid_negative_blob_gas_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=0, blob_gas_price=0),
+            True,
+            id="valid_zero_blob_gas_used_and_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=0, blob_gas_price=1),
+            True,
+            id="valid_zero_blob_gas_used_nonzero_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=1, blob_gas_price=0),
+            True,
+            id="valid_nonzero_blob_gas_used_zero_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=1, blob_gas_price=1),
+            True,
+            id="valid_nonzero_blob_gas_used_and_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=2, blob_gas_price=1),
+            True,
+            id="valid_blob_gas_used_greater_than_price",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=1, blob_gas_price=2),
+            True,
+            id="valid_blob_gas_price_greater_than_used",
+        ),
+        pytest.param(
+            make_receipt(blob_gas_used=2, blob_gas_price=2),
+            True,
+            id="valid_equal_blob_gas_used_and_price",
+        ),
+        pytest.param(
+            merge(make_receipt(), {"invalid-key": 1}), False, id="invalid_extra_key"
+        ),
     ),
 )
-def test_receipt_output_validation(validator, receipt, is_valid):
+def test_receipt_output_validation(
+    validator: DefaultValidator, receipt: Any, is_valid: bool
+) -> None:
     if is_valid:
         validator.validate_outbound_receipt(receipt)
     else:
@@ -374,152 +834,238 @@ def test_receipt_output_validation(validator, receipt, is_valid):
             validator.validate_outbound_receipt(receipt)
 
 
-def _make_block(
-    number=0,
-    hash=ZERO_32BYTES,
-    parent_hash=ZERO_32BYTES,
-    nonce=ZERO_8BYTES,
-    sha3_uncles=ZERO_32BYTES,
-    logs_bloom=0,
-    transactions_root=ZERO_32BYTES,
-    receipts_root=ZERO_32BYTES,
-    state_root=ZERO_32BYTES,
-    coinbase=ZERO_ADDRESS,
-    difficulty=0,
-    mix_hash=ZERO_32BYTES,
-    total_difficulty=0,
-    size=0,
-    extra_data=ZERO_32BYTES,
-    gas_limit=30029122,  # gas limit at London fork block 12965000 on mainnet
-    gas_used=21000,
-    timestamp=4000000,
-    transactions=None,
-    uncles=None,
-    base_fee_per_gas=1000000000,
-    withdrawals=None,
-    withdrawals_root=ZERO_32BYTES,
-):
-    block = {
-        "number": number,
-        "hash": hash,
-        "parent_hash": parent_hash,
-        "nonce": nonce,
-        "sha3_uncles": sha3_uncles,
-        "logs_bloom": logs_bloom,
-        "transactions_root": transactions_root,
-        "receipts_root": receipts_root,
-        "state_root": state_root,
-        "coinbase": coinbase,
-        "difficulty": difficulty,
-        "mix_hash": mix_hash,
-        "total_difficulty": total_difficulty,
-        "size": size,
-        "extra_data": extra_data,
-        "gas_limit": gas_limit,
-        "gas_used": gas_used,
-        "timestamp": timestamp,
-        "transactions": transactions or [],
-        "uncles": uncles or [],
-        "base_fee_per_gas": base_fee_per_gas,
-        "withdrawals": withdrawals or [],
-        "withdrawals_root": withdrawals_root,
-    }
-    return block
-
-
-def _make_withdrawal(
-    index: int = 2**64 - 1,
-    validator_index: int = 2**64 - 1,
-    address: bytes = ZERO_ADDRESS,
-    amount: int = 2**64 - 1,
-):
-    return {
-        "index": index,
-        "validator_index": validator_index,
-        "address": address,
-        "amount": amount,
-    }
-
-
 @pytest.mark.parametrize(
     "block,is_valid",
     (
-        (_make_block(), True),
-        (_make_block(number=-1), False),
-        (_make_block(number=1.0), False),
-        (_make_block(number=True), False),
-        (_make_block(hash=HASH32_AS_TEXT), False),
-        (_make_block(hash=HASH31), False),
-        (_make_block(parent_hash=HASH32_AS_TEXT), False),
-        (_make_block(parent_hash=HASH31), False),
-        (_make_block(nonce=-1), False),
-        (_make_block(nonce=1.0), False),
-        (_make_block(nonce=True), False),
-        (_make_block(sha3_uncles=HASH32_AS_TEXT), False),
-        (_make_block(logs_bloom=-1), False),
-        (_make_block(logs_bloom=1.0), False),
-        (_make_block(logs_bloom=True), False),
-        (_make_block(transactions_root=HASH32_AS_TEXT), False),
-        (_make_block(transactions_root=HASH31), False),
-        (_make_block(receipts_root=HASH32_AS_TEXT), False),
-        (_make_block(receipts_root=HASH31), False),
-        (_make_block(state_root=HASH32_AS_TEXT), False),
-        (_make_block(state_root=HASH31), False),
-        (_make_block(coinbase=encode_hex(ADDRESS_A)), False),
-        (_make_block(difficulty=-1), False),
-        (_make_block(difficulty=1.0), False),
-        (_make_block(difficulty=True), False),
-        (_make_block(mix_hash=HASH32_AS_TEXT), False),
-        (_make_block(mix_hash=HASH31), False),
-        (_make_block(total_difficulty=-1), False),
-        (_make_block(total_difficulty=1.0), False),
-        (_make_block(total_difficulty=True), False),
-        (_make_block(size=-1), False),
-        (_make_block(size=1.0), False),
-        (_make_block(size=True), False),
-        (_make_block(extra_data=HASH32_AS_TEXT), False),
-        (_make_block(extra_data=HASH31), False),
-        (_make_block(gas_limit=-1), False),
-        (_make_block(gas_limit=1.0), False),
-        (_make_block(gas_limit=True), False),
-        (_make_block(gas_used=-1), False),
-        (_make_block(gas_used=1.0), False),
-        (_make_block(gas_used=True), False),
-        (_make_block(timestamp=-1), False),
-        (_make_block(timestamp=1.0), False),
-        (_make_block(timestamp=True), False),
-        (_make_block(base_fee_per_gas=1000000000), True),
-        (_make_block(base_fee_per_gas=-1000000000), False),
-        (_make_block(base_fee_per_gas=1000000000.0), False),
-        (_make_block(base_fee_per_gas="1000000000"), False),
-        (_make_block(uncles=[ZERO_32BYTES]), True),
-        (_make_block(uncles=[ZERO_32BYTES, HASH32_AS_TEXT]), False),
-        (_make_block(transactions=[ZERO_32BYTES]), True),
-        (_make_block(transactions=[_make_legacy_txn()]), True),
-        (_make_block(transactions=[ZERO_32BYTES, _make_legacy_txn()]), False),
-        (_make_block(transactions=[_make_access_list_txn()]), True),
-        (_make_block(transactions=[ZERO_32BYTES, _make_access_list_txn()]), False),
-        (_make_block(transactions=[_make_dynamic_fee_txn()]), True),
-        (_make_block(transactions=[ZERO_32BYTES, _make_dynamic_fee_txn()]), False),
-        (_make_block(transactions=[ZERO_32BYTES, HASH32_AS_TEXT]), False),
-        (_make_block(withdrawals=[_make_withdrawal()]), True),
-        (_make_block(withdrawals=[_make_withdrawal(address=ADDRESS_A)]), True),
-        (_make_block(withdrawals=[_make_withdrawal(index=-1)]), False),
-        (_make_block(withdrawals=[_make_withdrawal(index=2**64)]), False),
-        (_make_block(withdrawals=[_make_withdrawal(validator_index=-1)]), False),
-        (_make_block(withdrawals=[_make_withdrawal(validator_index=2**64)]), False),
-        (_make_block(withdrawals=[_make_withdrawal(amount=-1)]), False),
-        (_make_block(withdrawals=[_make_withdrawal(amount=2**64)]), False),
-        (_make_block(withdrawals=[_make_withdrawal(address="1")]), False),
-        (
+        pytest.param(_make_block(), True, id="valid_block"),
+        pytest.param(_make_block(number=-1), False, id="invalid_negative_number"),
+        pytest.param(_make_block(number=1.0), False, id="invalid_float_number"),
+        pytest.param(_make_block(number=True), False, id="invalid_bool_number"),
+        pytest.param(_make_block(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"),
+        pytest.param(_make_block(hash=HASH31), False, id="invalid_short_hash"),
+        pytest.param(
+            _make_block(parent_hash=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_parent_hash",
+        ),
+        pytest.param(
+            _make_block(parent_hash=HASH31), False, id="invalid_short_parent_hash"
+        ),
+        pytest.param(_make_block(nonce=-1), False, id="invalid_negative_nonce"),
+        pytest.param(_make_block(nonce=1.0), False, id="invalid_float_nonce"),
+        pytest.param(_make_block(nonce=True), False, id="invalid_bool_nonce"),
+        pytest.param(
+            _make_block(sha3_uncles=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_sha3_uncles",
+        ),
+        pytest.param(
+            _make_block(logs_bloom=-1), False, id="invalid_negative_logs_bloom"
+        ),
+        pytest.param(_make_block(logs_bloom=1.0), False, id="invalid_float_logs_bloom"),
+        pytest.param(_make_block(logs_bloom=True), False, id="invalid_bool_logs_bloom"),
+        pytest.param(
+            _make_block(transactions_root=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_transactions_root",
+        ),
+        pytest.param(
+            _make_block(transactions_root=HASH31),
+            False,
+            id="invalid_short_transactions_root",
+        ),
+        pytest.param(
+            _make_block(receipts_root=HASH32_AS_TEXT),
+            False,
+            id="invalid_text_receipts_root",
+        ),
+        pytest.param(
+            _make_block(receipts_root=HASH31), False, id="invalid_short_receipts_root"
+        ),
+        pytest.param(
+            _make_block(state_root=HASH32_AS_TEXT), False, id="invalid_text_state_root"
+        ),
+        pytest.param(
+            _make_block(state_root=HASH31), False, id="invalid_short_state_root"
+        ),
+        pytest.param(
+            _make_block(coinbase=encode_hex(ADDRESS_A)),
+            False,
+            id="invalid_hex_coinbase",
+        ),
+        pytest.param(
+            _make_block(difficulty=-1), False, id="invalid_negative_difficulty"
+        ),
+        pytest.param(_make_block(difficulty=1.0), False, id="invalid_float_difficulty"),
+        pytest.param(_make_block(difficulty=True), False, id="invalid_bool_difficulty"),
+        pytest.param(
+            _make_block(mix_hash=HASH32_AS_TEXT), False, id="invalid_text_mix_hash"
+        ),
+        pytest.param(_make_block(mix_hash=HASH31), False, id="invalid_short_mix_hash"),
+        pytest.param(
+            _make_block(total_difficulty=-1),
+            False,
+            id="invalid_negative_total_difficulty",
+        ),
+        pytest.param(
+            _make_block(total_difficulty=1.0),
+            False,
+            id="invalid_float_total_difficulty",
+        ),
+        pytest.param(
+            _make_block(total_difficulty=True),
+            False,
+            id="invalid_bool_total_difficulty",
+        ),
+        pytest.param(_make_block(size=-1), False, id="invalid_negative_size"),
+        pytest.param(_make_block(size=1.0), False, id="invalid_float_size"),
+        pytest.param(_make_block(size=True), False, id="invalid_bool_size"),
+        pytest.param(
+            _make_block(extra_data=HASH32_AS_TEXT), False, id="invalid_text_extra_data"
+        ),
+        pytest.param(
+            _make_block(extra_data=HASH31), False, id="invalid_short_extra_data"
+        ),
+        pytest.param(_make_block(gas_limit=-1), False, id="invalid_negative_gas_limit"),
+        pytest.param(_make_block(gas_limit=1.0), False, id="invalid_float_gas_limit"),
+        pytest.param(_make_block(gas_limit=True), False, id="invalid_bool_gas_limit"),
+        pytest.param(_make_block(gas_used=-1), False, id="invalid_negative_gas_used"),
+        pytest.param(_make_block(gas_used=1.0), False, id="invalid_float_gas_used"),
+        pytest.param(_make_block(gas_used=True), False, id="invalid_bool_gas_used"),
+        pytest.param(_make_block(timestamp=-1), False, id="invalid_negative_timestamp"),
+        pytest.param(_make_block(timestamp=1.0), False, id="invalid_float_timestamp"),
+        pytest.param(_make_block(timestamp=True), False, id="invalid_bool_timestamp"),
+        pytest.param(
+            _make_block(base_fee_per_gas=1000000000), True, id="valid_base_fee"
+        ),
+        pytest.param(
+            _make_block(base_fee_per_gas=-1000000000),
+            False,
+            id="invalid_negative_base_fee",
+        ),
+        pytest.param(
+            _make_block(base_fee_per_gas=1000000000.0),
+            False,
+            id="invalid_float_base_fee",
+        ),
+        pytest.param(
+            _make_block(base_fee_per_gas="1000000000"),
+            False,
+            id="invalid_string_base_fee",
+        ),
+        pytest.param(_make_block(uncles=[ZERO_32BYTES]), True, id="valid_uncles"),
+        pytest.param(
+            _make_block(uncles=[ZERO_32BYTES, HASH32_AS_TEXT]),
+            False,
+            id="invalid_uncles_with_text",
+        ),
+        pytest.param(_make_block(transactions="invalid"), False, id="valid_transactions_string"),  # type: ignore[arg-type]
+        pytest.param(
+            _make_block(transactions=[ZERO_32BYTES]), True, id="valid_transactions_hash"
+        ),
+        pytest.param(
+            _make_block(transactions=[_make_legacy_txn()]),
+            True,
+            id="valid_transactions_legacy_txn",
+        ),
+        pytest.param(
+            _make_block(transactions=[ZERO_32BYTES, _make_legacy_txn()]),
+            False,
+            id="invalid_mixed_transactions",
+        ),
+        pytest.param(
+            _make_block(transactions=[_make_access_list_txn()]),
+            True,
+            id="valid_transactions_access_list",
+        ),
+        pytest.param(
+            _make_block(transactions=[ZERO_32BYTES, _make_access_list_txn()]),
+            False,
+            id="invalid_mixed_with_access_list",
+        ),
+        pytest.param(
+            _make_block(transactions=[_make_dynamic_fee_txn()]),
+            True,
+            id="valid_transactions_dynamic_fee",
+        ),
+        pytest.param(
+            _make_block(transactions=[ZERO_32BYTES, _make_dynamic_fee_txn()]),
+            False,
+            id="invalid_mixed_with_dynamic_fee",
+        ),
+        pytest.param(
+            _make_block(transactions=[_make_blob_txn()]),
+            True,
+            id="valid_transactions_blob",
+        ),
+        pytest.param(
+            _make_block(transactions=[ZERO_32BYTES, _make_blob_txn()]),
+            False,
+            id="invalid_mixed_with_blob",
+        ),
+        pytest.param(
+            _make_block(transactions=[ZERO_32BYTES, HASH32_AS_TEXT]),
+            False,
+            id="invalid_transactions_with_text",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal()]), True, id="valid_withdrawals"
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(address=ADDRESS_A)]),
+            True,
+            id="valid_withdrawal_with_address",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(index=-1)]),
+            False,
+            id="invalid_withdrawal_negative_index",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(index=2**64)]),
+            False,
+            id="invalid_withdrawal_index_too_large",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(validator_index=-1)]),
+            False,
+            id="invalid_withdrawal_negative_validator_index",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(validator_index=2**64)]),
+            False,
+            id="invalid_withdrawal_validator_index_too_large",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(amount=-1)]),
+            False,
+            id="invalid_withdrawal_negative_amount",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(amount=2**64)]),
+            False,
+            id="invalid_withdrawal_amount_too_large",
+        ),
+        pytest.param(
+            _make_block(withdrawals=[_make_withdrawal(address="1")]),
+            False,
+            id="invalid_withdrawal_string_address",
+        ),
+        pytest.param(
             _make_block(
                 withdrawals=[_make_withdrawal(address=encode_hex(ZERO_ADDRESS))]
             ),
             False,
+            id="invalid_withdrawal_hex_address",
+        ),
+        pytest.param(
+            merge(_make_block(), {"invalid-key": 1}), False, id="invalid_extra_key"
         ),
     ),
 )
-def test_block_output_validation(validator, block, is_valid):
+def test_block_output_validation(
+    validator: DefaultValidator, block: Any, is_valid: bool
+) -> None:
     if is_valid:
         validator.validate_outbound_block(block)
     else:
@@ -530,13 +1076,78 @@ def test_block_output_validation(validator, block, is_valid):
 @pytest.mark.parametrize(
     "accounts,is_valid",
     (
-        ([ADDRESS_A], True),
-        ([ADDRESS_A, encode_hex(ADDRESS_A)], False),
+        pytest.param([ADDRESS_A], True, id="valid_address"),
+        pytest.param([ADDRESS_A, encode_hex(ADDRESS_A)], False, id="invalid_hex"),
+        pytest.param(ADDRESS_A, False, id="invalid_not_list"),
+        pytest.param([b"0x"], False, id="invalid_bytes"),
+        pytest.param([1], False, id="invalid_int"),
     ),
 )
-def test_accounts_output_validation(validator, accounts, is_valid):
+def test_accounts_output_validation(
+    validator: DefaultValidator, accounts: Any, is_valid: bool
+) -> None:
     if is_valid:
         validator.validate_outbound_accounts(accounts)
     else:
         with pytest.raises(ValidationError):
             validator.validate_outbound_accounts(accounts)
+
+
+@pytest.mark.parametrize(
+    "value,is_valid",
+    [(b"", True), (b"0x", True), (1, False)],
+    ids=["valid", "invalid_hex", "invalid_int"],
+)
+@pytest.mark.parametrize(
+    "validator_name",
+    [
+        "validate_outbound_code",
+        "validate_outbound_return_data",
+    ],
+)
+def test_validate_outbound_value_bytes(
+    validator: DefaultValidator,
+    validator_name: str,
+    value: Any,
+    is_valid: bool,
+) -> None:
+    if is_valid:
+        getattr(validator, validator_name)(value)
+    else:
+        with pytest.raises(ValidationError):
+            getattr(validator, validator_name)(value)
+
+
+@pytest.mark.parametrize(
+    "value,is_valid",
+    [
+        pytest.param(0, True, id="valid_zero"),
+        pytest.param(1, True, id="valid_one"),
+        pytest.param(2**256 - 1, True, id="valid_max_uint256"),
+        pytest.param(2**256, False, id="invalid_too_large"),
+        pytest.param(2**256 + 1, False, id="invalid_too_large_plus_one"),
+        pytest.param(2**256 - 2, True, id="valid_max_uint256_minus_two"),
+        pytest.param(-1, False, id="invalid_negative"),
+        pytest.param("abc", False, id="invalid_string"),
+    ],
+)
+@pytest.mark.parametrize(
+    "validator_name",
+    [
+        "validate_outbound_balance",
+        "validate_outbound_gas_estimate",
+        "validate_outbound_nonce",
+        "validate_outbound_storage",
+    ],
+)
+def test_validate_outbound_value_uint256(
+    validator: DefaultValidator,
+    validator_name: str,
+    value: Any,
+    is_valid: bool,
+) -> None:
+    if is_valid:
+        getattr(validator, validator_name)(value)
+    else:
+        with pytest.raises(ValidationError):
+            getattr(validator, validator_name)(value)

--- a/tests/core/validation/test_outbound_validation.py
+++ b/tests/core/validation/test_outbound_validation.py
@@ -1,8 +1,8 @@
+import pytest
 from typing import (
     Any,
 )
 
-import pytest
 from eth_utils import (
     encode_hex,
 )

--- a/tests/core/validation/test_outbound_validation.py
+++ b/tests/core/validation/test_outbound_validation.py
@@ -38,105 +38,73 @@ from tests.utils import (
 
 
 @pytest.mark.parametrize(
-    "block_hash,is_valid",
+    "block_hash",
     (
-        pytest.param(ZERO_32BYTES, True, id="valid_bytes_all_zero"),
-        pytest.param(b"\xff" * 32, True, id="valid_bytes_all_ff"),
-        pytest.param(b"\x00", False, id="invalid_bytes_short"),
-        pytest.param("\x00" * 32, False, id="invalid_str"),
-        pytest.param(encode_hex(ZERO_32BYTES), False, id="invalid_hex"),
-        pytest.param(1, False, id="invalid_int"),
-        pytest.param(True, False, id="invalid_bool"),
+        pytest.param(ZERO_32BYTES, id="valid_bytes_all_zero"),
+        pytest.param(b"\xff" * 32, id="valid_bytes_all_ff"),
     ),
 )
 def test_block_hash_output_validation(
-    validator: DefaultValidator, block_hash: Any, is_valid: bool
+    validator: DefaultValidator, block_hash: Any
 ) -> None:
-    if is_valid:
-        validator.validate_outbound_block_hash(block_hash)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_block_hash(block_hash)
+    validator.validate_outbound_block_hash(block_hash)
 
 
 @pytest.mark.parametrize(
-    "value,is_valid",
-    [(ZERO_32BYTES, True), (ZERO_32BYTES + b"\x00", False), (b"0x", False), (1, False)],
-    ids=["valid", "invalid_too_long", "invalid_hex", "invalid_int"],
+    "block_hash",
+    (
+        pytest.param(b"\x00", id="invalid_bytes_short"),
+        pytest.param("\x00" * 32, id="invalid_str"),
+        pytest.param(encode_hex(ZERO_32BYTES), id="invalid_hex"),
+        pytest.param(1, id="invalid_int"),
+        pytest.param(True, id="invalid_bool"),
+    ),
+)
+def test_block_hash_output_validation_invalid(
+    validator: DefaultValidator, block_hash: Any
+) -> None:
+    with pytest.raises(ValidationError):
+        validator.validate_outbound_block_hash(block_hash)
+
+
+@pytest.mark.parametrize(
+    "hash", (pytest.param(ZERO_32BYTES, id="valid_bytes_all_zero"),)
 )
 def test_validate_outbound_transaction_hash(
     validator: DefaultValidator,
-    value: Any,
-    is_valid: bool,
+    hash: Any,
 ) -> None:
-    if is_valid:
-        validator.validate_outbound_transaction_hash(value)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_transaction_hash(value)
+    validator.validate_outbound_transaction_hash(hash)
 
 
 @pytest.mark.parametrize(
-    "transaction,is_valid",
+    "hash",
     (
-        pytest.param(make_legacy_txn(), True, id="valid_legacy_txn"),
-        pytest.param(make_access_list_txn(), True, id="valid_access_list_txn"),
-        pytest.param(make_dynamic_fee_txn(), True, id="valid_dynamic_fee_txn"),
-        pytest.param(make_blob_txn(), True, id="valid_blob_txn"),
-        pytest.param(
-            make_legacy_txn(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"
-        ),
-        pytest.param(make_legacy_txn(hash=HASH31), False, id="invalid_short_hash"),
-        pytest.param(make_legacy_txn(nonce=-1), False, id="invalid_negative_nonce"),
-        pytest.param(make_legacy_txn(nonce=1.0), False, id="invalid_float_nonce"),
-        pytest.param(make_legacy_txn(nonce=True), False, id="invalid_bool_nonce"),
-        pytest.param(make_legacy_txn(value=-1), False, id="invalid_negative_value"),
-        pytest.param(make_legacy_txn(value=1.0), False, id="invalid_float_value"),
-        pytest.param(make_legacy_txn(value=True), False, id="invalid_bool_value"),
-        pytest.param(
-            make_legacy_txn(block_number=-1),
-            False,
-            id="invalid_negative_block_number",
-        ),
-        pytest.param(
-            make_legacy_txn(block_number=1.0),
-            False,
-            id="invalid_float_block_number",
-        ),
-        pytest.param(
-            make_legacy_txn(block_number=True),
-            False,
-            id="invalid_bool_block_number",
-        ),
-        pytest.param(make_legacy_txn(gas=-1), False, id="invalid_negative_gas"),
-        pytest.param(make_legacy_txn(gas=1.0), False, id="invalid_float_gas"),
-        pytest.param(make_legacy_txn(gas=True), False, id="invalid_bool_gas"),
-        pytest.param(
-            make_legacy_txn(gas_price=-1),
-            False,
-            id="invalid_negative_gas_price",
-        ),
-        pytest.param(
-            make_legacy_txn(gas_price=1.0), False, id="invalid_float_gas_price"
-        ),
-        pytest.param(
-            make_legacy_txn(gas_price=True), False, id="invalid_bool_gas_price"
-        ),
-        pytest.param(make_legacy_txn(data=""), False, id="invalid_empty_string_data"),
-        pytest.param(make_legacy_txn(data="0x"), False, id="invalid_0x_string_data"),
-        pytest.param(
-            make_legacy_txn(block_hash=HASH32_AS_TEXT),
-            False,
-            id="invalid_text_block_hash",
-        ),
-        pytest.param(
-            make_legacy_txn(block_hash=HASH31),
-            False,
-            id="invalid_short_block_hash",
-        ),
+        pytest.param(b"\x00", id="invalid_bytes_short"),
+        pytest.param(b"\xff" * 31, id="invalid_bytes_short_ff"),
+        pytest.param(f"0x{'00' * 32}", id="invalid_hex_string"),
+        pytest.param("0x0", id="invalid_hex_string_short"),
+        pytest.param(1, id="invalid_int"),
+        pytest.param(True, id="invalid_bool"),
+    ),
+)
+def test_validate_outbound_transaction_hash_invalid(
+    validator: DefaultValidator,
+    hash: Any,
+) -> None:
+    with pytest.raises(ValidationError):
+        validator.validate_outbound_transaction_hash(hash)
+
+
+@pytest.mark.parametrize(
+    "transaction",
+    (
+        pytest.param(make_legacy_txn(), id="valid_legacy_txn"),
+        pytest.param(make_access_list_txn(), id="valid_access_list_txn"),
+        pytest.param(make_dynamic_fee_txn(), id="valid_dynamic_fee_txn"),
+        pytest.param(make_blob_txn(), id="valid_blob_txn"),
         pytest.param(
             make_legacy_txn(transaction_index=None, block_hash=None, block_number=None),
-            True,
             id="valid_pending_legacy_txn",
         ),
         pytest.param(
@@ -145,7 +113,6 @@ def test_validate_outbound_transaction_hash(
                 block_hash=None,
                 block_number=None,
             ),
-            True,
             id="valid_pending_access_list_txn",
         ),
         pytest.param(
@@ -154,7 +121,6 @@ def test_validate_outbound_transaction_hash(
                 block_hash=None,
                 block_number=None,
             ),
-            True,
             id="valid_pending_dynamic_fee_txn",
         ),
         pytest.param(
@@ -163,238 +129,248 @@ def test_validate_outbound_transaction_hash(
                 block_hash=None,
                 block_number=None,
             ),
-            True,
             id="valid_pending_blob_txn",
         ),
-        pytest.param(
-            make_access_list_txn(chain_id="1"),
-            False,
-            id="invalid_string_chain_id_access_list",
-        ),
-        pytest.param(
-            make_dynamic_fee_txn(chain_id="1"),
-            False,
-            id="invalid_string_chain_id_dynamic_fee",
-        ),
-        pytest.param(
-            make_blob_txn(chain_id="1"),
-            False,
-            id="invalid_string_chain_id_blob",
-        ),
-        pytest.param(
-            make_access_list_txn(chain_id=-1),
-            False,
-            id="invalid_negative_chain_id_access_list",
-        ),
-        pytest.param(
-            make_dynamic_fee_txn(chain_id=-1),
-            False,
-            id="invalid_negative_chain_id_dynamic_fee",
-        ),
-        pytest.param(
-            make_blob_txn(chain_id=-1),
-            False,
-            id="invalid_negative_chain_id_blob",
-        ),
-        pytest.param(
-            make_access_list_txn(chain_id=None),
-            False,
-            id="invalid_none_chain_id_access_list",
-        ),
-        pytest.param(
-            make_dynamic_fee_txn(chain_id=None),
-            False,
-            id="invalid_none_chain_id_dynamic_fee",
-        ),
-        pytest.param(
-            make_blob_txn(chain_id=None), False, id="invalid_none_chain_id_blob"
-        ),
-        pytest.param(make_legacy_txn(v=0), True, id="valid_v_0_legacy"),
-        pytest.param(make_dynamic_fee_txn(v=0), True, id="valid_v_0_dynamic_fee"),
-        pytest.param(make_access_list_txn(v=0), True, id="valid_v_0_access_list"),
-        pytest.param(make_blob_txn(v=0), True, id="valid_v_0_blob"),
-        pytest.param(make_legacy_txn(v=1), True, id="valid_v_1_legacy"),
-        pytest.param(make_dynamic_fee_txn(v=1), True, id="valid_v_1_dynamic_fee"),
-        pytest.param(make_access_list_txn(v=1), True, id="valid_v_1_access_list"),
-        pytest.param(make_blob_txn(v=1), True, id="valid_v_1_blob"),
-        pytest.param(make_legacy_txn(v=27), True, id="valid_v_27_legacy"),
-        pytest.param(make_access_list_txn(v=27), False, id="invalid_v_27_access_list"),
-        pytest.param(make_dynamic_fee_txn(v=27), False, id="invalid_v_27_dynamic_fee"),
-        pytest.param(make_blob_txn(v=27), False, id="invalid_v_27_blob"),
-        pytest.param(
-            make_dynamic_fee_txn(max_fee_per_gas=1.0),
-            False,
-            id="invalid_float_max_fee_per_gas",
-        ),
-        pytest.param(
-            make_dynamic_fee_txn(max_priority_fee_per_gas=1.0),
-            False,
-            id="invalid_float_max_priority_fee",
-        ),
-        pytest.param(
-            make_dynamic_fee_txn(max_fee_per_gas="1"),
-            False,
-            id="invalid_string_max_fee_per_gas",
-        ),
-        pytest.param(
-            make_dynamic_fee_txn(max_priority_fee_per_gas="1"),
-            False,
-            id="invalid_string_max_priority_fee",
-        ),
-        pytest.param(
-            make_blob_txn(max_fee_per_blob_gas=1.0),
-            False,
-            id="invalid_float_max_fee_per_blob_gas",
-        ),
-        pytest.param(
-            make_blob_txn(max_fee_per_blob_gas="1"),
-            False,
-            id="invalid_string_max_fee_per_blob_gas",
-        ),
+        pytest.param(make_legacy_txn(v=0), id="valid_v_0_legacy"),
+        pytest.param(make_dynamic_fee_txn(v=0), id="valid_v_0_dynamic_fee"),
+        pytest.param(make_access_list_txn(v=0), id="valid_v_0_access_list"),
+        pytest.param(make_blob_txn(v=0), id="valid_v_0_blob"),
+        pytest.param(make_legacy_txn(v=1), id="valid_v_1_legacy"),
+        pytest.param(make_dynamic_fee_txn(v=1), id="valid_v_1_dynamic_fee"),
+        pytest.param(make_access_list_txn(v=1), id="valid_v_1_access_list"),
+        pytest.param(make_blob_txn(v=1), id="valid_v_1_blob"),
+        pytest.param(make_legacy_txn(v=27), id="valid_v_27_legacy"),
         pytest.param(
             make_blob_txn(blob_versioned_hashes=""),  # type: ignore[arg-type]
-            True,
             id="valid_string_blob_hashes",
         ),
         pytest.param(
             make_blob_txn(blob_versioned_hashes=()),
-            True,
             id="valid_empty_blob_hashes",
         ),
         pytest.param(
-            make_blob_txn(blob_versioned_hashes=("",)),
-            False,
-            id="invalid_empty_string_in_blob_hashes",
-        ),
-        pytest.param(
             make_blob_txn(blob_versioned_hashes=(ZERO_32BYTES,)),
-            True,
             id="valid_bytes32_blob_hash",
-        ),
-        pytest.param(
-            make_blob_txn(blob_versioned_hashes=(b"\x00" * 31,)),
-            False,
-            id="invalid_bytes31_blob_hash",
-        ),
-        pytest.param(
-            make_blob_txn(blob_versioned_hashes=(b"\x00",)),
-            False,
-            id="invalid_bytes1_blob_hash",
         ),
         pytest.param(
             make_access_list_txn(
                 access_list=((b"\xf0" * 20, (0, 2)),),
             ),
-            True,
             id="valid_access_list_with_storage_keys",
         ),
         pytest.param(
             make_dynamic_fee_txn(
                 access_list=((b"\xef" * 20, (1, 2, 3, 4)),),
             ),
-            True,
             id="valid_dynamic_fee_with_storage_keys",
         ),
         pytest.param(
             make_blob_txn(
                 access_list=((b"\xef" * 20, (1, 2, 3, 4)),),
             ),
-            True,
             id="valid_blob_with_storage_keys",
         ),
         pytest.param(
             make_access_list_txn(access_list=()),
-            True,
             id="valid_empty_access_list",
         ),
         pytest.param(
             make_dynamic_fee_txn(access_list=()),
-            True,
             id="valid_empty_dynamic_fee_access_list",
         ),
         pytest.param(
             make_blob_txn(access_list=()),
-            True,
             id="valid_empty_blob_access_list",
+        ),
+    ),
+)
+def test_transaction_output_validation(
+    validator: DefaultValidator, transaction: Any
+) -> None:
+    validator.validate_outbound_transaction(transaction)
+
+
+@pytest.mark.parametrize(
+    "transaction",
+    (
+        pytest.param(make_legacy_txn(hash=HASH32_AS_TEXT), id="invalid_text_hash"),
+        pytest.param(make_legacy_txn(hash=HASH31), id="invalid_short_hash"),
+        pytest.param(make_legacy_txn(nonce=-1), id="invalid_negative_nonce"),
+        pytest.param(make_legacy_txn(nonce=1.0), id="invalid_float_nonce"),
+        pytest.param(make_legacy_txn(nonce=True), id="invalid_bool_nonce"),
+        pytest.param(make_legacy_txn(value=-1), id="invalid_negative_value"),
+        pytest.param(make_legacy_txn(value=1.0), id="invalid_float_value"),
+        pytest.param(make_legacy_txn(value=True), id="invalid_bool_value"),
+        pytest.param(
+            make_legacy_txn(block_number=-1),
+            id="invalid_negative_block_number",
+        ),
+        pytest.param(
+            make_legacy_txn(block_number=1.0),
+            id="invalid_float_block_number",
+        ),
+        pytest.param(
+            make_legacy_txn(block_number=True),
+            id="invalid_bool_block_number",
+        ),
+        pytest.param(make_legacy_txn(gas=-1), id="invalid_negative_gas"),
+        pytest.param(make_legacy_txn(gas=1.0), id="invalid_float_gas"),
+        pytest.param(make_legacy_txn(gas=True), id="invalid_bool_gas"),
+        pytest.param(
+            make_legacy_txn(gas_price=-1),
+            id="invalid_negative_gas_price",
+        ),
+        pytest.param(make_legacy_txn(gas_price=1.0), id="invalid_float_gas_price"),
+        pytest.param(make_legacy_txn(gas_price=True), id="invalid_bool_gas_price"),
+        pytest.param(make_legacy_txn(data=""), id="invalid_empty_string_data"),
+        pytest.param(make_legacy_txn(data="0x"), id="invalid_0x_string_data"),
+        pytest.param(
+            make_legacy_txn(block_hash=HASH32_AS_TEXT),
+            id="invalid_text_block_hash",
+        ),
+        pytest.param(
+            make_legacy_txn(block_hash=HASH31),
+            id="invalid_short_block_hash",
+        ),
+        pytest.param(
+            make_access_list_txn(chain_id="1"),
+            id="invalid_string_chain_id_access_list",
+        ),
+        pytest.param(
+            make_dynamic_fee_txn(chain_id="1"),
+            id="invalid_string_chain_id_dynamic_fee",
+        ),
+        pytest.param(
+            make_blob_txn(chain_id="1"),
+            id="invalid_string_chain_id_blob",
+        ),
+        pytest.param(
+            make_access_list_txn(chain_id=-1),
+            id="invalid_negative_chain_id_access_list",
+        ),
+        pytest.param(
+            make_dynamic_fee_txn(chain_id=-1),
+            id="invalid_negative_chain_id_dynamic_fee",
+        ),
+        pytest.param(
+            make_blob_txn(chain_id=-1),
+            id="invalid_negative_chain_id_blob",
+        ),
+        pytest.param(
+            make_access_list_txn(chain_id=None),
+            id="invalid_none_chain_id_access_list",
+        ),
+        pytest.param(
+            make_dynamic_fee_txn(chain_id=None),
+            id="invalid_none_chain_id_dynamic_fee",
+        ),
+        pytest.param(make_blob_txn(chain_id=None), id="invalid_none_chain_id_blob"),
+        pytest.param(make_access_list_txn(v=27), id="invalid_v_27_access_list"),
+        pytest.param(make_dynamic_fee_txn(v=27), id="invalid_v_27_dynamic_fee"),
+        pytest.param(make_blob_txn(v=27), id="invalid_v_27_blob"),
+        pytest.param(
+            make_dynamic_fee_txn(max_fee_per_gas=1.0),
+            id="invalid_float_max_fee_per_gas",
+        ),
+        pytest.param(
+            make_dynamic_fee_txn(max_priority_fee_per_gas=1.0),
+            id="invalid_float_max_priority_fee",
+        ),
+        pytest.param(
+            make_dynamic_fee_txn(max_fee_per_gas="1"),
+            id="invalid_string_max_fee_per_gas",
+        ),
+        pytest.param(
+            make_dynamic_fee_txn(max_priority_fee_per_gas="1"),
+            id="invalid_string_max_priority_fee",
+        ),
+        pytest.param(
+            make_blob_txn(max_fee_per_blob_gas=1.0),
+            id="invalid_float_max_fee_per_blob_gas",
+        ),
+        pytest.param(
+            make_blob_txn(max_fee_per_blob_gas="1"),
+            id="invalid_string_max_fee_per_blob_gas",
+        ),
+        pytest.param(
+            make_blob_txn(blob_versioned_hashes=("",)),
+            id="invalid_empty_string_in_blob_hashes",
+        ),
+        pytest.param(
+            make_blob_txn(blob_versioned_hashes=(b"\x00" * 31,)),
+            id="invalid_bytes31_blob_hash",
+        ),
+        pytest.param(
+            make_blob_txn(blob_versioned_hashes=(b"\x00",)),
+            id="invalid_bytes1_blob_hash",
         ),
         pytest.param(
             make_access_list_txn(
                 access_list=((b"\xf0" * 19, (0, 2)),),
             ),
-            False,
             id="invalid_short_address_in_access_list",
         ),
         pytest.param(
             make_dynamic_fee_txn(
                 access_list=((b"\xf0" * 19, ()),),
             ),
-            False,
             id="invalid_short_address_with_empty_storage_keys",
         ),
         pytest.param(
             make_blob_txn(
                 access_list=((b"\xf0" * 19, ()),),
             ),
-            False,
             id="invalid_short_address_in_blob_access_list",
         ),
         pytest.param(
             make_access_list_txn(
                 access_list=((b"\xf0" * 20, ("0", 2)),),
             ),
-            False,
             id="invalid_string_storage_key",
         ),
         pytest.param(
             make_dynamic_fee_txn(
                 access_list=((b"\xf0" * 20, (b"", 1)),),
             ),
-            False,
             id="invalid_empty_bytes_storage_key",
         ),
         pytest.param(
             make_blob_txn(
                 access_list=((b"\xf0" * 20, (b"", 1)),),
             ),
-            False,
             id="invalid_empty_bytes_storage_key_in_blob",
         ),
         pytest.param(
             make_dynamic_fee_txn(
                 access_list=(("", (1, 2)),),
             ),
-            False,
             id="invalid_empty_string_address_in_access_list",
         ),
         pytest.param(
             make_blob_txn(
                 access_list=(("", (1, 2)),),
             ),
-            False,
             id="invalid_empty_string_address_in_blob_access_list",
         ),
-        pytest.param({}, False, id="invalid_empty_dict"),
+        pytest.param({}, id="invalid_empty_dict"),
         pytest.param(
             merge(make_legacy_txn(), {"invalid-key": 1}),
-            False,
             id="invalid_extra_key",
         ),
     ),
 )
-def test_transaction_output_validation(
-    validator: DefaultValidator, transaction: Any, is_valid: bool
+def test_transaction_output_validation_invalid(
+    validator: DefaultValidator,
+    transaction: Any,
 ) -> None:
-    if is_valid:
+    with pytest.raises(ValidationError):
         validator.validate_outbound_transaction(transaction)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_transaction(transaction)
 
 
 @pytest.mark.parametrize(
-    "log_entry,is_valid",
+    "log_entry",
     (
-        pytest.param(make_log(), True, id="valid_standard_log"),
+        pytest.param(make_log(), id="valid_standard_log"),
         pytest.param(
             make_log(
                 _type="pending",
@@ -402,7 +378,6 @@ def test_transaction_output_validation(
                 block_hash=None,
                 block_number=None,
             ),
-            True,
             id="valid_pending_log",
         ),
         pytest.param(
@@ -412,495 +387,347 @@ def test_transaction_output_validation(
                 block_hash=None,
                 block_number=None,
             ),
-            True,
             id="valid_mined_log_with_nulls",
         ),
-        pytest.param(make_log(_type="invalid-type"), False, id="invalid_log_type"),
+        pytest.param(make_log(topics=[TOPIC_A, TOPIC_B]), id="valid_multiple_topics"),
+        pytest.param(make_log(address=ADDRESS_A), id="valid_address"),
+    ),
+)
+def test_log_entry_output_validation(
+    validator: DefaultValidator, log_entry: Any
+) -> None:
+    validator.validate_outbound_log_entry(log_entry)
+
+
+@pytest.mark.parametrize(
+    "log_entry",
+    (
+        pytest.param(make_log(_type="invalid-type"), id="invalid_log_type"),
         pytest.param(
             make_log(transaction_index=-1),
-            False,
             id="invalid_negative_transaction_index",
         ),
-        pytest.param(
-            make_log(block_number=-1), False, id="invalid_negative_block_number"
-        ),
+        pytest.param(make_log(block_number=-1), id="invalid_negative_block_number"),
         pytest.param(
             make_log(transaction_hash=HASH31),
-            False,
             id="invalid_short_transaction_hash",
         ),
         pytest.param(
             make_log(transaction_hash=HASH32_AS_TEXT),
-            False,
             id="invalid_text_transaction_hash",
         ),
-        pytest.param(make_log(block_hash=HASH31), False, id="invalid_short_block_hash"),
-        pytest.param(
-            make_log(block_hash=HASH32_AS_TEXT), False, id="invalid_text_block_hash"
-        ),
-        pytest.param(
-            make_log(address=encode_hex(ADDRESS_A)), False, id="invalid_hex_address"
-        ),
-        pytest.param(make_log(data=""), False, id="invalid_empty_string_data"),
-        pytest.param(make_log(data=None), False, id="invalid_none_data"),
-        pytest.param(make_log(topics=[HASH32_AS_TEXT]), False, id="invalid_text_topic"),
-        pytest.param(make_log(topics=[HASH31]), False, id="invalid_short_topic"),
-        pytest.param(
-            make_log(topics=[TOPIC_A, TOPIC_B]), True, id="valid_multiple_topics"
-        ),
+        pytest.param(make_log(block_hash=HASH31), id="invalid_short_block_hash"),
+        pytest.param(make_log(block_hash=HASH32_AS_TEXT), id="invalid_text_block_hash"),
+        pytest.param(make_log(address=encode_hex(ADDRESS_A)), id="invalid_hex_address"),
+        pytest.param(make_log(data=""), id="invalid_empty_string_data"),
+        pytest.param(make_log(data=None), id="invalid_none_data"),
+        pytest.param(make_log(topics=[HASH32_AS_TEXT]), id="invalid_text_topic"),
+        pytest.param(make_log(topics=[HASH31]), id="invalid_short_topic"),
         pytest.param(
             make_log(topics="invalid-topics"),  # type: ignore[arg-type]
-            False,
             id="invalid_string_topics",
         ),
-        pytest.param(make_log(address=ADDRESS_A), True, id="valid_address"),
-        pytest.param(
-            merge(make_log(), {"invalid-key": 1}), False, id="invalid_extra_key"
-        ),
+        pytest.param(merge(make_log(), {"invalid-key": 1}), id="invalid_extra_key"),
     ),
 )
-def test_log_entry_output_validation(
-    validator: DefaultValidator, log_entry: Any, is_valid: bool
+def test_log_entry_output_validation_invalid(
+    validator: DefaultValidator, log_entry: Any
 ) -> None:
-    if is_valid:
+    with pytest.raises(ValidationError):
         validator.validate_outbound_log_entry(log_entry)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_log_entry(log_entry)
 
 
 @pytest.mark.parametrize(
-    "receipt,is_valid",
+    "receipt",
     (
-        pytest.param(make_receipt(), True, id="valid_standard_receipt"),
-        pytest.param(
-            make_receipt(transaction_hash=HASH32_AS_TEXT),
-            False,
-            id="invalid_text_transaction_hash",
-        ),
-        pytest.param(
-            make_receipt(transaction_hash=HASH31),
-            False,
-            id="invalid_short_transaction_hash",
-        ),
-        pytest.param(
-            make_receipt(block_hash=HASH32_AS_TEXT), False, id="invalid_text_block_hash"
-        ),
-        pytest.param(
-            make_receipt(block_hash=HASH31), False, id="invalid_short_block_hash"
-        ),
-        pytest.param(
-            make_receipt(transaction_index=-1),
-            False,
-            id="invalid_negative_transaction_index",
-        ),
-        pytest.param(
-            make_receipt(transaction_index=1.0),
-            False,
-            id="invalid_float_transaction_index",
-        ),
-        pytest.param(
-            make_receipt(transaction_index=True),
-            False,
-            id="invalid_bool_transaction_index",
-        ),
-        pytest.param(
-            make_receipt(block_number=-1), False, id="invalid_negative_block_number"
-        ),
-        pytest.param(
-            make_receipt(block_number=1.0), False, id="invalid_float_block_number"
-        ),
-        pytest.param(
-            make_receipt(block_number=True), False, id="invalid_bool_block_number"
-        ),
-        pytest.param(make_receipt(gas_used=-1), False, id="invalid_negative_gas_used"),
-        pytest.param(make_receipt(gas_used=1.0), False, id="invalid_float_gas_used"),
-        pytest.param(make_receipt(gas_used=True), False, id="invalid_bool_gas_used"),
-        pytest.param(
-            make_receipt(cumulative_gas_used=-1),
-            False,
-            id="invalid_negative_cumulative_gas_used",
-        ),
-        pytest.param(
-            make_receipt(cumulative_gas_used=1.0),
-            False,
-            id="invalid_float_cumulative_gas_used",
-        ),
-        pytest.param(
-            make_receipt(cumulative_gas_used=True),
-            False,
-            id="invalid_bool_cumulative_gas_used",
-        ),
+        pytest.param(make_receipt(), id="valid_standard_receipt"),
         pytest.param(
             make_receipt(contract_address=ZERO_ADDRESS),
-            True,
             id="valid_contract_address",
         ),
         pytest.param(
-            make_receipt(contract_address=encode_hex(ZERO_ADDRESS)),
-            False,
-            id="invalid_hex_contract_address",
-        ),
-        pytest.param(make_receipt(logs=[make_log()]), True, id="valid_logs"),
-        pytest.param(
-            make_receipt(logs=[make_log(_type="invalid")]),
-            False,
-            id="invalid_log_type_in_logs",
-        ),
-        pytest.param(
             make_receipt(_from=ADDRESS_A, to=ADDRESS_A),
-            True,
             id="valid_from_to_same_address",
         ),
         pytest.param(
             make_receipt(_from=ADDRESS_A, to=ZERO_ADDRESS),
-            True,
             id="valid_from_to_different_address",
         ),
-        pytest.param(
-            make_receipt(_from=encode_hex(ZERO_ADDRESS), to=ADDRESS_A),
-            False,
-            id="invalid_hex_from_address",
-        ),
-        pytest.param(
-            make_receipt(_from=ADDRESS_A, to=encode_hex(ZERO_ADDRESS)),
-            False,
-            id="invalid_hex_to_address",
-        ),
-        pytest.param(make_receipt(status=0), True, id="valid_status_0"),
-        pytest.param(make_receipt(status=1), True, id="valid_status_1"),
-        pytest.param(make_receipt(status=2), False, id="invalid_status_2"),
-        pytest.param(make_receipt(status=-1), False, id="invalid_negative_status"),
-        pytest.param(
-            make_receipt(blob_gas_used=-1, blob_gas_price=-1),
-            False,
-            id="invalid_negative_blob_gas_used_and_price",
-        ),
-        pytest.param(
-            make_receipt(blob_gas_used=-1, blob_gas_price=0),
-            False,
-            id="invalid_negative_blob_gas_used",
-        ),
-        pytest.param(
-            make_receipt(blob_gas_used=0, blob_gas_price=-1),
-            False,
-            id="invalid_negative_blob_gas_price",
-        ),
+        pytest.param(make_receipt(status=0), id="valid_status_0"),
+        pytest.param(make_receipt(status=1), id="valid_status_1"),
+        pytest.param(make_receipt(logs=[make_log()]), id="valid_logs"),
         pytest.param(
             make_receipt(blob_gas_used=0, blob_gas_price=0),
-            True,
             id="valid_zero_blob_gas_used_and_price",
         ),
         pytest.param(
             make_receipt(blob_gas_used=0, blob_gas_price=1),
-            True,
             id="valid_zero_blob_gas_used_nonzero_price",
         ),
         pytest.param(
             make_receipt(blob_gas_used=1, blob_gas_price=0),
-            True,
             id="valid_nonzero_blob_gas_used_zero_price",
         ),
         pytest.param(
             make_receipt(blob_gas_used=1, blob_gas_price=1),
-            True,
             id="valid_nonzero_blob_gas_used_and_price",
         ),
         pytest.param(
             make_receipt(blob_gas_used=2, blob_gas_price=1),
-            True,
             id="valid_blob_gas_used_greater_than_price",
         ),
         pytest.param(
             make_receipt(blob_gas_used=1, blob_gas_price=2),
-            True,
             id="valid_blob_gas_price_greater_than_used",
         ),
         pytest.param(
             make_receipt(blob_gas_used=2, blob_gas_price=2),
-            True,
             id="valid_equal_blob_gas_used_and_price",
-        ),
-        pytest.param(
-            merge(make_receipt(), {"invalid-key": 1}), False, id="invalid_extra_key"
         ),
     ),
 )
-def test_receipt_output_validation(
-    validator: DefaultValidator, receipt: Any, is_valid: bool
-) -> None:
-    if is_valid:
-        validator.validate_outbound_receipt(receipt)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_receipt(receipt)
+def test_receipt_output_validation(validator: DefaultValidator, receipt: Any) -> None:
+    validator.validate_outbound_receipt(receipt)
 
 
 @pytest.mark.parametrize(
-    "block,is_valid",
+    "receipt",
     (
-        pytest.param(make_block(), True, id="valid_block"),
-        pytest.param(make_block(number=-1), False, id="invalid_negative_number"),
-        pytest.param(make_block(number=1.0), False, id="invalid_float_number"),
-        pytest.param(make_block(number=True), False, id="invalid_bool_number"),
-        pytest.param(make_block(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"),
-        pytest.param(make_block(hash=HASH31), False, id="invalid_short_hash"),
         pytest.param(
-            make_block(parent_hash=HASH32_AS_TEXT),
-            False,
-            id="invalid_text_parent_hash",
+            make_receipt(transaction_hash=HASH32_AS_TEXT),
+            id="invalid_text_transaction_hash",
         ),
         pytest.param(
-            make_block(parent_hash=HASH31), False, id="invalid_short_parent_hash"
-        ),
-        pytest.param(make_block(nonce=-1), False, id="invalid_negative_nonce"),
-        pytest.param(make_block(nonce=1.0), False, id="invalid_float_nonce"),
-        pytest.param(make_block(nonce=True), False, id="invalid_bool_nonce"),
-        pytest.param(
-            make_block(sha3_uncles=HASH32_AS_TEXT),
-            False,
-            id="invalid_text_sha3_uncles",
+            make_receipt(transaction_hash=HASH31),
+            id="invalid_short_transaction_hash",
         ),
         pytest.param(
-            make_block(logs_bloom=-1), False, id="invalid_negative_logs_bloom"
+            make_receipt(block_hash=HASH32_AS_TEXT), id="invalid_text_block_hash"
         ),
-        pytest.param(make_block(logs_bloom=1.0), False, id="invalid_float_logs_bloom"),
-        pytest.param(make_block(logs_bloom=True), False, id="invalid_bool_logs_bloom"),
+        pytest.param(make_receipt(block_hash=HASH31), id="invalid_short_block_hash"),
         pytest.param(
-            make_block(transactions_root=HASH32_AS_TEXT),
-            False,
-            id="invalid_text_transactions_root",
+            make_receipt(transaction_index=-1),
+            id="invalid_negative_transaction_index",
         ),
         pytest.param(
-            make_block(transactions_root=HASH31),
-            False,
-            id="invalid_short_transactions_root",
+            make_receipt(transaction_index=1.0),
+            id="invalid_float_transaction_index",
         ),
         pytest.param(
-            make_block(receipts_root=HASH32_AS_TEXT),
-            False,
-            id="invalid_text_receipts_root",
+            make_receipt(transaction_index=True),
+            id="invalid_bool_transaction_index",
+        ),
+        pytest.param(make_receipt(block_number=-1), id="invalid_negative_block_number"),
+        pytest.param(make_receipt(block_number=1.0), id="invalid_float_block_number"),
+        pytest.param(make_receipt(block_number=True), id="invalid_bool_block_number"),
+        pytest.param(make_receipt(gas_used=-1), id="invalid_negative_gas_used"),
+        pytest.param(make_receipt(gas_used=1.0), id="invalid_float_gas_used"),
+        pytest.param(make_receipt(gas_used=True), id="invalid_bool_gas_used"),
+        pytest.param(
+            make_receipt(cumulative_gas_used=-1),
+            id="invalid_negative_cumulative_gas_used",
         ),
         pytest.param(
-            make_block(receipts_root=HASH31), False, id="invalid_short_receipts_root"
+            make_receipt(cumulative_gas_used=1.0),
+            id="invalid_float_cumulative_gas_used",
         ),
         pytest.param(
-            make_block(state_root=HASH32_AS_TEXT), False, id="invalid_text_state_root"
+            make_receipt(cumulative_gas_used=True),
+            id="invalid_bool_cumulative_gas_used",
         ),
         pytest.param(
-            make_block(state_root=HASH31), False, id="invalid_short_state_root"
+            make_receipt(contract_address=encode_hex(ZERO_ADDRESS)),
+            id="invalid_hex_contract_address",
         ),
         pytest.param(
-            make_block(coinbase=encode_hex(ADDRESS_A)),
-            False,
-            id="invalid_hex_coinbase",
+            make_receipt(logs=[make_log(_type="invalid")]),
+            id="invalid_log_type_in_logs",
         ),
         pytest.param(
-            make_block(difficulty=-1), False, id="invalid_negative_difficulty"
-        ),
-        pytest.param(make_block(difficulty=1.0), False, id="invalid_float_difficulty"),
-        pytest.param(make_block(difficulty=True), False, id="invalid_bool_difficulty"),
-        pytest.param(
-            make_block(mix_hash=HASH32_AS_TEXT), False, id="invalid_text_mix_hash"
-        ),
-        pytest.param(make_block(mix_hash=HASH31), False, id="invalid_short_mix_hash"),
-        pytest.param(
-            make_block(total_difficulty=-1),
-            False,
-            id="invalid_negative_total_difficulty",
+            make_receipt(_from=encode_hex(ZERO_ADDRESS), to=ADDRESS_A),
+            id="invalid_hex_from_address",
         ),
         pytest.param(
-            make_block(total_difficulty=1.0),
-            False,
-            id="invalid_float_total_difficulty",
+            make_receipt(_from=ADDRESS_A, to=encode_hex(ZERO_ADDRESS)),
+            id="invalid_hex_to_address",
+        ),
+        pytest.param(make_receipt(status=2), id="invalid_status_2"),
+        pytest.param(make_receipt(status=-1), id="invalid_negative_status"),
+        pytest.param(
+            make_receipt(blob_gas_used=-1, blob_gas_price=-1),
+            id="invalid_negative_blob_gas_used_and_price",
         ),
         pytest.param(
-            make_block(total_difficulty=True),
-            False,
-            id="invalid_bool_total_difficulty",
-        ),
-        pytest.param(make_block(size=-1), False, id="invalid_negative_size"),
-        pytest.param(make_block(size=1.0), False, id="invalid_float_size"),
-        pytest.param(make_block(size=True), False, id="invalid_bool_size"),
-        pytest.param(
-            make_block(extra_data=HASH32_AS_TEXT), False, id="invalid_text_extra_data"
+            make_receipt(blob_gas_used=-1, blob_gas_price=0),
+            id="invalid_negative_blob_gas_used",
         ),
         pytest.param(
-            make_block(extra_data=HASH31), False, id="invalid_short_extra_data"
+            make_receipt(blob_gas_used=0, blob_gas_price=-1),
+            id="invalid_negative_blob_gas_price",
         ),
-        pytest.param(make_block(gas_limit=-1), False, id="invalid_negative_gas_limit"),
-        pytest.param(make_block(gas_limit=1.0), False, id="invalid_float_gas_limit"),
-        pytest.param(make_block(gas_limit=True), False, id="invalid_bool_gas_limit"),
-        pytest.param(make_block(gas_used=-1), False, id="invalid_negative_gas_used"),
-        pytest.param(make_block(gas_used=1.0), False, id="invalid_float_gas_used"),
-        pytest.param(make_block(gas_used=True), False, id="invalid_bool_gas_used"),
-        pytest.param(make_block(timestamp=-1), False, id="invalid_negative_timestamp"),
-        pytest.param(make_block(timestamp=1.0), False, id="invalid_float_timestamp"),
-        pytest.param(make_block(timestamp=True), False, id="invalid_bool_timestamp"),
+        pytest.param(merge(make_receipt(), {"invalid-key": 1}), id="invalid_extra_key"),
+    ),
+)
+def test_receipt_output_validation_invalid(
+    validator: DefaultValidator, receipt: Any
+) -> None:
+    with pytest.raises(ValidationError):
+        validator.validate_outbound_receipt(receipt)
+
+
+@pytest.mark.parametrize(
+    "block",
+    (
+        pytest.param(make_block(), id="valid_block"),
+        pytest.param(make_block(base_fee_per_gas=1000000000), id="valid_base_fee"),
         pytest.param(
-            make_block(base_fee_per_gas=1000000000), True, id="valid_base_fee"
+            make_block(transactions=[ZERO_32BYTES]), id="valid_transactions_hash"
         ),
+        pytest.param(make_block(uncles=[ZERO_32BYTES]), id="valid_uncles"),
+        pytest.param(
+            make_block(transactions=[make_legacy_txn()]),
+            id="valid_transactions_legacy_txn",
+        ),
+        pytest.param(
+            make_block(transactions=[make_access_list_txn()]),
+            id="valid_transactions_access_list",
+        ),
+        pytest.param(
+            make_block(transactions=[make_dynamic_fee_txn()]),
+            id="valid_transactions_dynamic_fee",
+        ),
+        pytest.param(
+            make_block(transactions=[make_blob_txn()]),
+            id="valid_transactions_blob",
+        ),
+        pytest.param(
+            make_block(withdrawals=[make_withdrawal()]), id="valid_withdrawals"
+        ),
+        pytest.param(
+            make_block(withdrawals=[make_withdrawal(address=ADDRESS_A)]),
+            id="valid_withdrawal_with_address",
+        ),
+    ),
+)
+def test_block_output_validation(validator: DefaultValidator, block: Any) -> None:
+    validator.validate_outbound_block(block)
+
+
+@pytest.mark.parametrize(
+    "block",
+    (
         pytest.param(
             make_block(base_fee_per_gas=-1000000000),
-            False,
             id="invalid_negative_base_fee",
         ),
         pytest.param(
             make_block(base_fee_per_gas=1000000000.0),
-            False,
             id="invalid_float_base_fee",
         ),
         pytest.param(
             make_block(base_fee_per_gas="1000000000"),
-            False,
             id="invalid_string_base_fee",
         ),
-        pytest.param(make_block(uncles=[ZERO_32BYTES]), True, id="valid_uncles"),
         pytest.param(
             make_block(uncles=[ZERO_32BYTES, HASH32_AS_TEXT]),
-            False,
             id="invalid_uncles_with_text",
         ),
         pytest.param(
             make_block(transactions="invalid"),  # type: ignore[arg-type]
-            False,
-            id="valid_transactions_string",
-        ),
-        pytest.param(
-            make_block(transactions=[ZERO_32BYTES]), True, id="valid_transactions_hash"
-        ),
-        pytest.param(
-            make_block(transactions=[make_legacy_txn()]),
-            True,
-            id="valid_transactions_legacy_txn",
+            id="invalid_transactions_string",
         ),
         pytest.param(
             make_block(transactions=[ZERO_32BYTES, make_legacy_txn()]),
-            False,
             id="invalid_mixed_transactions",
         ),
         pytest.param(
-            make_block(transactions=[make_access_list_txn()]),
-            True,
-            id="valid_transactions_access_list",
-        ),
-        pytest.param(
             make_block(transactions=[ZERO_32BYTES, make_access_list_txn()]),
-            False,
             id="invalid_mixed_with_access_list",
         ),
         pytest.param(
-            make_block(transactions=[make_dynamic_fee_txn()]),
-            True,
-            id="valid_transactions_dynamic_fee",
-        ),
-        pytest.param(
             make_block(transactions=[ZERO_32BYTES, make_dynamic_fee_txn()]),
-            False,
             id="invalid_mixed_with_dynamic_fee",
         ),
         pytest.param(
-            make_block(transactions=[make_blob_txn()]),
-            True,
-            id="valid_transactions_blob",
-        ),
-        pytest.param(
             make_block(transactions=[ZERO_32BYTES, make_blob_txn()]),
-            False,
             id="invalid_mixed_with_blob",
         ),
         pytest.param(
             make_block(transactions=[ZERO_32BYTES, HASH32_AS_TEXT]),
-            False,
             id="invalid_transactions_with_text",
         ),
         pytest.param(
-            make_block(withdrawals=[make_withdrawal()]), True, id="valid_withdrawals"
-        ),
-        pytest.param(
-            make_block(withdrawals=[make_withdrawal(address=ADDRESS_A)]),
-            True,
-            id="valid_withdrawal_with_address",
-        ),
-        pytest.param(
             make_block(withdrawals=[make_withdrawal(index=-1)]),
-            False,
             id="invalid_withdrawal_negative_index",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(index=2**64)]),
-            False,
             id="invalid_withdrawal_index_too_large",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(validator_index=-1)]),
-            False,
             id="invalid_withdrawal_negative_validator_index",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(validator_index=2**64)]),
-            False,
             id="invalid_withdrawal_validator_index_too_large",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(amount=-1)]),
-            False,
             id="invalid_withdrawal_negative_amount",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(amount=2**64)]),
-            False,
             id="invalid_withdrawal_amount_too_large",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(address="1")]),
-            False,
             id="invalid_withdrawal_string_address",
         ),
         pytest.param(
             make_block(withdrawals=[make_withdrawal(address=encode_hex(ZERO_ADDRESS))]),
-            False,
             id="invalid_withdrawal_hex_address",
         ),
-        pytest.param(
-            merge(make_block(), {"invalid-key": 1}), False, id="invalid_extra_key"
-        ),
+        pytest.param(merge(make_block(), {"invalid-key": 1}), id="invalid_extra_key"),
     ),
 )
-def test_block_output_validation(
-    validator: DefaultValidator, block: Any, is_valid: bool
+def test_block_output_validation_invalid(
+    validator: DefaultValidator, block: Any
 ) -> None:
-    if is_valid:
+    with pytest.raises(ValidationError):
         validator.validate_outbound_block(block)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_block(block)
 
 
 @pytest.mark.parametrize(
-    "accounts,is_valid",
+    "accounts",
+    (pytest.param([ADDRESS_A], id="valid_address"),),
+)
+def test_accounts_output_validation(validator: DefaultValidator, accounts: Any) -> None:
+    validator.validate_outbound_accounts(accounts)
+
+
+@pytest.mark.parametrize(
+    "accounts",
     (
-        pytest.param([ADDRESS_A], True, id="valid_address"),
-        pytest.param([ADDRESS_A, encode_hex(ADDRESS_A)], False, id="invalid_hex"),
-        pytest.param(ADDRESS_A, False, id="invalid_not_list"),
-        pytest.param([b"0x"], False, id="invalid_bytes"),
-        pytest.param([1], False, id="invalid_int"),
+        pytest.param([ADDRESS_A, encode_hex(ADDRESS_A)], id="invalid_hex"),
+        pytest.param(ADDRESS_A, id="invalid_not_list"),
+        pytest.param([b"0x"], id="invalid_bytes"),
+        pytest.param([1], id="invalid_int"),
     ),
 )
-def test_accounts_output_validation(
-    validator: DefaultValidator, accounts: Any, is_valid: bool
+def test_accounts_output_validation_invalid(
+    validator: DefaultValidator, accounts: Any
 ) -> None:
-    if is_valid:
+    with pytest.raises(ValidationError):
         validator.validate_outbound_accounts(accounts)
-    else:
-        with pytest.raises(ValidationError):
-            validator.validate_outbound_accounts(accounts)
 
 
 @pytest.mark.parametrize(
-    "value,is_valid",
-    [(b"", True), (b"0x", True), (1, False)],
-    ids=["valid", "invalid_hex", "invalid_int"],
+    "value",
+    (
+        pytest.param(b"", id="valid_empty_bytes"),
+        pytest.param(b"0x", id="valid_empty_hex"),
+    ),
 )
 @pytest.mark.parametrize(
     "validator_name",
@@ -913,26 +740,34 @@ def test_validate_outbound_value_bytes(
     validator: DefaultValidator,
     validator_name: str,
     value: Any,
-    is_valid: bool,
 ) -> None:
-    if is_valid:
+    getattr(validator, validator_name)(value)
+
+
+@pytest.mark.parametrize("value", (pytest.param(1, id="invalid_int"),))
+@pytest.mark.parametrize(
+    "validator_name",
+    [
+        "validate_outbound_code",
+        "validate_outbound_return_data",
+    ],
+)
+def test_validate_outbound_value_bytes_invalid(
+    value: Any,
+    validator: DefaultValidator,
+    validator_name: str,
+) -> None:
+    with pytest.raises(ValidationError):
         getattr(validator, validator_name)(value)
-    else:
-        with pytest.raises(ValidationError):
-            getattr(validator, validator_name)(value)
 
 
 @pytest.mark.parametrize(
-    "value,is_valid",
+    "value",
     [
-        pytest.param(0, True, id="valid_zero"),
-        pytest.param(1, True, id="valid_one"),
-        pytest.param(2**256 - 1, True, id="valid_max_uint256"),
-        pytest.param(2**256, False, id="invalid_too_large"),
-        pytest.param(2**256 + 1, False, id="invalid_too_large_plus_one"),
-        pytest.param(2**256 - 2, True, id="valid_max_uint256_minus_two"),
-        pytest.param(-1, False, id="invalid_negative"),
-        pytest.param("abc", False, id="invalid_string"),
+        pytest.param(0, id="valid_zero"),
+        pytest.param(1, id="valid_one"),
+        pytest.param(2**256 - 1, id="valid_max_uint256"),
+        pytest.param(2**256 - 2, id="valid_max_uint256_minus_two"),
     ],
 )
 @pytest.mark.parametrize(
@@ -948,10 +783,32 @@ def test_validate_outbound_value_uint256(
     validator: DefaultValidator,
     validator_name: str,
     value: Any,
-    is_valid: bool,
 ) -> None:
-    if is_valid:
+    getattr(validator, validator_name)(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(2**256, id="invalid_too_large"),
+        pytest.param(2**256 + 1, id="invalid_too_large_plus_one"),
+        pytest.param(-1, id="invalid_negative"),
+        pytest.param("abc", id="invalid_string"),
+    ],
+)
+@pytest.mark.parametrize(
+    "validator_name",
+    [
+        "validate_outbound_balance",
+        "validate_outbound_gas_estimate",
+        "validate_outbound_nonce",
+        "validate_outbound_storage",
+    ],
+)
+def test_validate_outbound_value_uint256_invalid(
+    validator: DefaultValidator,
+    validator_name: str,
+    value: Any,
+) -> None:
+    with pytest.raises(ValidationError):
         getattr(validator, validator_name)(value)
-    else:
-        with pytest.raises(ValidationError):
-            getattr(validator, validator_name)(value)

--- a/tests/core/validation/test_outbound_validation.py
+++ b/tests/core/validation/test_outbound_validation.py
@@ -1,9 +1,5 @@
 from typing import (
     Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
 )
 
 import pytest
@@ -11,16 +7,9 @@ from eth_utils import (
     encode_hex,
 )
 from toolz import (
-    dissoc,
     merge,
 )
 
-from eth_tester.constants import (
-    ACCESS_LIST_TX_TYPE,
-    BLOB_TX_TYPE,
-    DYNAMIC_FEE_TX_TYPE,
-    LEGACY_TX_TYPE,
-)
 from eth_tester.exceptions import (
     ValidationError,
 )
@@ -29,232 +18,23 @@ from eth_tester.validation import (
 )
 from tests.constants import (
     ADDRESS_A,
-    DEFAULT_GAS_LIMIT,
     HASH31,
     HASH32_AS_TEXT,
     TOPIC_A,
     TOPIC_B,
-    ZERO_8BYTES,
     ZERO_32BYTES,
     ZERO_ADDRESS,
 )
 from tests.utils import (
+    make_access_list_txn,
+    make_blob_txn,
+    make_block,
+    make_dynamic_fee_txn,
+    make_legacy_txn,
+    make_log,
     make_receipt,
+    make_withdrawal,
 )
-
-
-def _make_legacy_txn(
-    hash: Any = ZERO_32BYTES,
-    nonce: Any = 0,
-    block_hash: Optional[Any] = ZERO_32BYTES,
-    block_number: Optional[Any] = 0,
-    transaction_index: Optional[int] = 0,
-    _from: Any = ZERO_ADDRESS,
-    to: Any = ZERO_ADDRESS,
-    value: Any = 0,
-    gas: Any = DEFAULT_GAS_LIMIT,
-    gas_price: Any = 1,
-    data: Any = b"",
-    v: Any = 0,
-    r: Any = 0,
-    s: Any = 0,
-) -> Dict[str, Any]:
-    return {
-        "type": LEGACY_TX_TYPE,
-        "hash": hash,
-        "nonce": nonce,
-        "blockHash": block_hash,
-        "blockNumber": block_number,
-        "transactionIndex": transaction_index,
-        "from": _from,
-        "to": to,
-        "value": value,
-        "gas": gas,
-        "gasPrice": gas_price,
-        "data": data,
-        "s": s,
-        "r": r,
-        "v": v,
-    }
-
-
-def _make_access_list_txn(
-    chain_id: Any = 131277322940537,
-    access_list: Tuple[Any, ...] = (),
-    **kwargs: Any,
-) -> Dict[str, Any]:
-    legacy_kwargs = dissoc(dict(**kwargs), "chain_id", "access_list")
-    return dict(
-        merge(
-            _make_legacy_txn(**legacy_kwargs),
-            {
-                "type": ACCESS_LIST_TX_TYPE,
-                "chainId": chain_id,
-                "accessList": list(access_list),
-                "yParity": legacy_kwargs.get("v", 0),
-            },
-        )
-    )
-
-
-# This is an outbound transaction so we still keep the gas_price for now since the
-# gas_price is the min(max_fee_per_gas, base_fee_per_gas + max_priority_fee_per_gas).
-# TODO: Sometime in 2022 the inclusion of gas_price may be removed from dynamic fee
-#  transactions and we can get rid of this behavior.
-#  https://github.com/ethereum/execution-specs/pull/251
-def _make_dynamic_fee_txn(
-    chain_id: Any = 131277322940537,
-    max_fee_per_gas: Any = 2000000000,
-    max_priority_fee_per_gas: Any = 1000000000,
-    access_list: Tuple[Any, ...] = (),
-    **kwargs: Any,
-) -> Dict[str, Any]:
-    legacy_kwargs = dissoc(
-        dict(**kwargs),
-        "chainId",
-        "maxFeePerGas",
-        "maxPriorityFeePerGas",
-        "accessList",
-    )
-    return dict(
-        merge(
-            _make_access_list_txn(
-                chain_id=chain_id, access_list=access_list, **legacy_kwargs
-            ),
-            {
-                "type": DYNAMIC_FEE_TX_TYPE,
-                "maxFeePerGas": max_fee_per_gas,
-                "maxPriorityFeePerGas": max_priority_fee_per_gas,
-            },
-        )
-    )
-
-
-def _make_blob_txn(
-    chain_id: Any = 131277322940537,
-    max_fee_per_gas: Any = 2000000000,
-    max_priority_fee_per_gas: Any = 1000000000,
-    access_list: Tuple[Any, ...] = (),
-    max_fee_per_blob_gas: Any = 1000000000,
-    blob_versioned_hashes: Tuple[Any, ...] = (),
-    **kwargs: Any,
-) -> Dict[str, Any]:
-    legacy_kwargs = dissoc(
-        dict(**kwargs),
-        "chainId",
-        "maxFeePerGas",
-        "maxPriorityFeePerGas",
-        "accessList",
-        "maxFeePerBlobGas",
-        "blobVersionedHashes",
-    )
-    return dict(
-        merge(
-            _make_dynamic_fee_txn(
-                chain_id=chain_id,
-                access_list=access_list,
-                max_fee_per_gas=max_fee_per_gas,
-                max_priority_fee_per_gas=max_priority_fee_per_gas,
-                **legacy_kwargs,
-            ),
-            {
-                "type": BLOB_TX_TYPE,
-                "maxFeePerBlobGas": max_fee_per_blob_gas,
-                "blobVersionedHashes": list(blob_versioned_hashes),
-            },
-        )
-    )
-
-
-def _make_log(
-    _type: Any = "mined",
-    log_index: Any = 0,
-    transaction_index: Any = 0,
-    transaction_hash: Any = ZERO_32BYTES,
-    block_hash: Any = ZERO_32BYTES,
-    block_number: Any = 0,
-    address: Any = ZERO_ADDRESS,
-    data: Any = b"",
-    topics: Optional[List[Any]] = None,
-) -> Dict[str, Any]:
-    return {
-        "type": _type,
-        "logIndex": log_index,
-        "transactionIndex": transaction_index,
-        "transactionHash": transaction_hash,
-        "blockHash": block_hash,
-        "blockNumber": block_number,
-        "address": address,
-        "data": data,
-        "topics": topics or [],
-    }
-
-
-def _make_block(
-    number: Any = 0,
-    hash: Any = ZERO_32BYTES,
-    parent_hash: Any = ZERO_32BYTES,
-    nonce: Any = ZERO_8BYTES,
-    sha3_uncles: Any = ZERO_32BYTES,
-    logs_bloom: Any = 0,
-    transactions_root: Any = ZERO_32BYTES,
-    receipts_root: Any = ZERO_32BYTES,
-    state_root: Any = ZERO_32BYTES,
-    coinbase: Any = ZERO_ADDRESS,
-    difficulty: Any = 0,
-    mix_hash: Any = ZERO_32BYTES,
-    total_difficulty: Any = 0,
-    size: Any = 0,
-    extra_data: Any = ZERO_32BYTES,
-    gas_limit: Any = 30029122,  # gas limit at London fork block 12965000 on mainnet
-    gas_used: Any = 21000,
-    timestamp: Any = 4000000,
-    transactions: Optional[List[Any]] = None,
-    uncles: Optional[List[Any]] = None,
-    base_fee_per_gas: Any = 1000000000,
-    withdrawals: Optional[List[Any]] = None,
-    withdrawals_root: Any = ZERO_32BYTES,
-) -> Dict[str, Any]:
-    block = {
-        "number": number,
-        "hash": hash,
-        "parentHash": parent_hash,
-        "nonce": nonce,
-        "sha3Uncles": sha3_uncles,
-        "logsBloom": logs_bloom,
-        "transactionsRoot": transactions_root,
-        "receiptsRoot": receipts_root,
-        "stateRoot": state_root,
-        "coinbase": coinbase,
-        "difficulty": difficulty,
-        "mixHash": mix_hash,
-        "totalDifficulty": total_difficulty,
-        "size": size,
-        "extraData": extra_data,
-        "gasLimit": gas_limit,
-        "gasUsed": gas_used,
-        "timestamp": timestamp,
-        "transactions": transactions or [],
-        "uncles": uncles or [],
-        "baseFeePerGas": base_fee_per_gas,
-        "withdrawals": withdrawals or [],
-        "withdrawalsRoot": withdrawals_root,
-    }
-    return block
-
-
-def _make_withdrawal(
-    index: Any = 2**64 - 1,
-    validator_index: Any = 2**64 - 1,
-    address: Any = ZERO_ADDRESS,
-    amount: Any = 2**64 - 1,
-) -> Dict[str, Any]:
-    return {
-        "index": index,
-        "validatorIndex": validator_index,
-        "address": address,
-        "amount": amount,
-    }
 
 
 @pytest.mark.parametrize(
@@ -299,60 +79,68 @@ def test_validate_outbound_transaction_hash(
 @pytest.mark.parametrize(
     "transaction,is_valid",
     (
-        pytest.param(_make_legacy_txn(), True, id="valid_legacy_txn"),
-        pytest.param(_make_access_list_txn(), True, id="valid_access_list_txn"),
-        pytest.param(_make_dynamic_fee_txn(), True, id="valid_dynamic_fee_txn"),
-        pytest.param(_make_blob_txn(), True, id="valid_blob_txn"),
+        pytest.param(make_legacy_txn(), True, id="valid_legacy_txn"),
+        pytest.param(make_access_list_txn(), True, id="valid_access_list_txn"),
+        pytest.param(make_dynamic_fee_txn(), True, id="valid_dynamic_fee_txn"),
+        pytest.param(make_blob_txn(), True, id="valid_blob_txn"),
         pytest.param(
-            _make_legacy_txn(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"
+            make_legacy_txn(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"
         ),
-        pytest.param(_make_legacy_txn(hash=HASH31), False, id="invalid_short_hash"),
-        pytest.param(_make_legacy_txn(nonce=-1), False, id="invalid_negative_nonce"),
-        pytest.param(_make_legacy_txn(nonce=1.0), False, id="invalid_float_nonce"),
-        pytest.param(_make_legacy_txn(nonce=True), False, id="invalid_bool_nonce"),
-        pytest.param(_make_legacy_txn(value=-1), False, id="invalid_negative_value"),
-        pytest.param(_make_legacy_txn(value=1.0), False, id="invalid_float_value"),
-        pytest.param(_make_legacy_txn(value=True), False, id="invalid_bool_value"),
+        pytest.param(make_legacy_txn(hash=HASH31), False, id="invalid_short_hash"),
+        pytest.param(make_legacy_txn(nonce=-1), False, id="invalid_negative_nonce"),
+        pytest.param(make_legacy_txn(nonce=1.0), False, id="invalid_float_nonce"),
+        pytest.param(make_legacy_txn(nonce=True), False, id="invalid_bool_nonce"),
+        pytest.param(make_legacy_txn(value=-1), False, id="invalid_negative_value"),
+        pytest.param(make_legacy_txn(value=1.0), False, id="invalid_float_value"),
+        pytest.param(make_legacy_txn(value=True), False, id="invalid_bool_value"),
         pytest.param(
-            _make_legacy_txn(block_number=-1), False, id="invalid_negative_block_number"
-        ),
-        pytest.param(
-            _make_legacy_txn(block_number=1.0), False, id="invalid_float_block_number"
-        ),
-        pytest.param(
-            _make_legacy_txn(block_number=True), False, id="invalid_bool_block_number"
-        ),
-        pytest.param(_make_legacy_txn(gas=-1), False, id="invalid_negative_gas"),
-        pytest.param(_make_legacy_txn(gas=1.0), False, id="invalid_float_gas"),
-        pytest.param(_make_legacy_txn(gas=True), False, id="invalid_bool_gas"),
-        pytest.param(
-            _make_legacy_txn(gas_price=-1), False, id="invalid_negative_gas_price"
+            make_legacy_txn(block_number=-1),
+            False,
+            id="invalid_negative_block_number",
         ),
         pytest.param(
-            _make_legacy_txn(gas_price=1.0), False, id="invalid_float_gas_price"
+            make_legacy_txn(block_number=1.0),
+            False,
+            id="invalid_float_block_number",
         ),
         pytest.param(
-            _make_legacy_txn(gas_price=True), False, id="invalid_bool_gas_price"
+            make_legacy_txn(block_number=True),
+            False,
+            id="invalid_bool_block_number",
         ),
-        pytest.param(_make_legacy_txn(data=""), False, id="invalid_empty_string_data"),
-        pytest.param(_make_legacy_txn(data="0x"), False, id="invalid_0x_string_data"),
+        pytest.param(make_legacy_txn(gas=-1), False, id="invalid_negative_gas"),
+        pytest.param(make_legacy_txn(gas=1.0), False, id="invalid_float_gas"),
+        pytest.param(make_legacy_txn(gas=True), False, id="invalid_bool_gas"),
         pytest.param(
-            _make_legacy_txn(block_hash=HASH32_AS_TEXT),
+            make_legacy_txn(gas_price=-1),
+            False,
+            id="invalid_negative_gas_price",
+        ),
+        pytest.param(
+            make_legacy_txn(gas_price=1.0), False, id="invalid_float_gas_price"
+        ),
+        pytest.param(
+            make_legacy_txn(gas_price=True), False, id="invalid_bool_gas_price"
+        ),
+        pytest.param(make_legacy_txn(data=""), False, id="invalid_empty_string_data"),
+        pytest.param(make_legacy_txn(data="0x"), False, id="invalid_0x_string_data"),
+        pytest.param(
+            make_legacy_txn(block_hash=HASH32_AS_TEXT),
             False,
             id="invalid_text_block_hash",
         ),
         pytest.param(
-            _make_legacy_txn(block_hash=HASH31), False, id="invalid_short_block_hash"
+            make_legacy_txn(block_hash=HASH31),
+            False,
+            id="invalid_short_block_hash",
         ),
         pytest.param(
-            _make_legacy_txn(
-                transaction_index=None, block_hash=None, block_number=None
-            ),
+            make_legacy_txn(transaction_index=None, block_hash=None, block_number=None),
             True,
             id="valid_pending_legacy_txn",
         ),
         pytest.param(
-            _make_access_list_txn(
+            make_access_list_txn(
                 transaction_index=None,
                 block_hash=None,
                 block_number=None,
@@ -361,7 +149,7 @@ def test_validate_outbound_transaction_hash(
             id="valid_pending_access_list_txn",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(
+            make_dynamic_fee_txn(
                 transaction_index=None,
                 block_hash=None,
                 block_number=None,
@@ -370,7 +158,7 @@ def test_validate_outbound_transaction_hash(
             id="valid_pending_dynamic_fee_txn",
         ),
         pytest.param(
-            _make_blob_txn(
+            make_blob_txn(
                 transaction_index=None,
                 block_hash=None,
                 block_number=None,
@@ -379,193 +167,207 @@ def test_validate_outbound_transaction_hash(
             id="valid_pending_blob_txn",
         ),
         pytest.param(
-            _make_access_list_txn(chain_id="1"),
+            make_access_list_txn(chain_id="1"),
             False,
             id="invalid_string_chain_id_access_list",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(chain_id="1"),
+            make_dynamic_fee_txn(chain_id="1"),
             False,
             id="invalid_string_chain_id_dynamic_fee",
         ),
         pytest.param(
-            _make_blob_txn(chain_id="1"), False, id="invalid_string_chain_id_blob"
+            make_blob_txn(chain_id="1"),
+            False,
+            id="invalid_string_chain_id_blob",
         ),
         pytest.param(
-            _make_access_list_txn(chain_id=-1),
+            make_access_list_txn(chain_id=-1),
             False,
             id="invalid_negative_chain_id_access_list",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(chain_id=-1),
+            make_dynamic_fee_txn(chain_id=-1),
             False,
             id="invalid_negative_chain_id_dynamic_fee",
         ),
         pytest.param(
-            _make_blob_txn(chain_id=-1), False, id="invalid_negative_chain_id_blob"
+            make_blob_txn(chain_id=-1),
+            False,
+            id="invalid_negative_chain_id_blob",
         ),
         pytest.param(
-            _make_access_list_txn(chain_id=None),
+            make_access_list_txn(chain_id=None),
             False,
             id="invalid_none_chain_id_access_list",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(chain_id=None),
+            make_dynamic_fee_txn(chain_id=None),
             False,
             id="invalid_none_chain_id_dynamic_fee",
         ),
         pytest.param(
-            _make_blob_txn(chain_id=None), False, id="invalid_none_chain_id_blob"
+            make_blob_txn(chain_id=None), False, id="invalid_none_chain_id_blob"
         ),
-        pytest.param(_make_legacy_txn(v=0), True, id="valid_v_0_legacy"),
-        pytest.param(_make_dynamic_fee_txn(v=0), True, id="valid_v_0_dynamic_fee"),
-        pytest.param(_make_access_list_txn(v=0), True, id="valid_v_0_access_list"),
-        pytest.param(_make_blob_txn(v=0), True, id="valid_v_0_blob"),
-        pytest.param(_make_legacy_txn(v=1), True, id="valid_v_1_legacy"),
-        pytest.param(_make_dynamic_fee_txn(v=1), True, id="valid_v_1_dynamic_fee"),
-        pytest.param(_make_access_list_txn(v=1), True, id="valid_v_1_access_list"),
-        pytest.param(_make_blob_txn(v=1), True, id="valid_v_1_blob"),
-        pytest.param(_make_legacy_txn(v=27), True, id="valid_v_27_legacy"),
-        pytest.param(_make_access_list_txn(v=27), False, id="invalid_v_27_access_list"),
-        pytest.param(_make_dynamic_fee_txn(v=27), False, id="invalid_v_27_dynamic_fee"),
-        pytest.param(_make_blob_txn(v=27), False, id="invalid_v_27_blob"),
+        pytest.param(make_legacy_txn(v=0), True, id="valid_v_0_legacy"),
+        pytest.param(make_dynamic_fee_txn(v=0), True, id="valid_v_0_dynamic_fee"),
+        pytest.param(make_access_list_txn(v=0), True, id="valid_v_0_access_list"),
+        pytest.param(make_blob_txn(v=0), True, id="valid_v_0_blob"),
+        pytest.param(make_legacy_txn(v=1), True, id="valid_v_1_legacy"),
+        pytest.param(make_dynamic_fee_txn(v=1), True, id="valid_v_1_dynamic_fee"),
+        pytest.param(make_access_list_txn(v=1), True, id="valid_v_1_access_list"),
+        pytest.param(make_blob_txn(v=1), True, id="valid_v_1_blob"),
+        pytest.param(make_legacy_txn(v=27), True, id="valid_v_27_legacy"),
+        pytest.param(make_access_list_txn(v=27), False, id="invalid_v_27_access_list"),
+        pytest.param(make_dynamic_fee_txn(v=27), False, id="invalid_v_27_dynamic_fee"),
+        pytest.param(make_blob_txn(v=27), False, id="invalid_v_27_blob"),
         pytest.param(
-            _make_dynamic_fee_txn(max_fee_per_gas=1.0),
+            make_dynamic_fee_txn(max_fee_per_gas=1.0),
             False,
             id="invalid_float_max_fee_per_gas",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(max_priority_fee_per_gas=1.0),
+            make_dynamic_fee_txn(max_priority_fee_per_gas=1.0),
             False,
             id="invalid_float_max_priority_fee",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(max_fee_per_gas="1"),
+            make_dynamic_fee_txn(max_fee_per_gas="1"),
             False,
             id="invalid_string_max_fee_per_gas",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(max_priority_fee_per_gas="1"),
+            make_dynamic_fee_txn(max_priority_fee_per_gas="1"),
             False,
             id="invalid_string_max_priority_fee",
         ),
         pytest.param(
-            _make_blob_txn(max_fee_per_blob_gas=1.0),
+            make_blob_txn(max_fee_per_blob_gas=1.0),
             False,
             id="invalid_float_max_fee_per_blob_gas",
         ),
         pytest.param(
-            _make_blob_txn(max_fee_per_blob_gas="1"),
+            make_blob_txn(max_fee_per_blob_gas="1"),
             False,
             id="invalid_string_max_fee_per_blob_gas",
         ),
-        pytest.param(_make_blob_txn(blob_versioned_hashes=""), True, id="valid_string_blob_hashes"),  # type: ignore[arg-type]
         pytest.param(
-            _make_blob_txn(blob_versioned_hashes=()), True, id="valid_empty_blob_hashes"
+            make_blob_txn(blob_versioned_hashes=""),  # type: ignore[arg-type]
+            True,
+            id="valid_string_blob_hashes",
         ),
         pytest.param(
-            _make_blob_txn(blob_versioned_hashes=("",)),
+            make_blob_txn(blob_versioned_hashes=()),
+            True,
+            id="valid_empty_blob_hashes",
+        ),
+        pytest.param(
+            make_blob_txn(blob_versioned_hashes=("",)),
             False,
             id="invalid_empty_string_in_blob_hashes",
         ),
         pytest.param(
-            _make_blob_txn(blob_versioned_hashes=(ZERO_32BYTES,)),
+            make_blob_txn(blob_versioned_hashes=(ZERO_32BYTES,)),
             True,
             id="valid_bytes32_blob_hash",
         ),
         pytest.param(
-            _make_blob_txn(blob_versioned_hashes=(b"\x00" * 31,)),
+            make_blob_txn(blob_versioned_hashes=(b"\x00" * 31,)),
             False,
             id="invalid_bytes31_blob_hash",
         ),
         pytest.param(
-            _make_blob_txn(blob_versioned_hashes=(b"\x00",)),
+            make_blob_txn(blob_versioned_hashes=(b"\x00",)),
             False,
             id="invalid_bytes1_blob_hash",
         ),
         pytest.param(
-            _make_access_list_txn(
+            make_access_list_txn(
                 access_list=((b"\xf0" * 20, (0, 2)),),
             ),
             True,
             id="valid_access_list_with_storage_keys",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(
+            make_dynamic_fee_txn(
                 access_list=((b"\xef" * 20, (1, 2, 3, 4)),),
             ),
             True,
             id="valid_dynamic_fee_with_storage_keys",
         ),
         pytest.param(
-            _make_blob_txn(
+            make_blob_txn(
                 access_list=((b"\xef" * 20, (1, 2, 3, 4)),),
             ),
             True,
             id="valid_blob_with_storage_keys",
         ),
         pytest.param(
-            _make_access_list_txn(access_list=()), True, id="valid_empty_access_list"
+            make_access_list_txn(access_list=()),
+            True,
+            id="valid_empty_access_list",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(access_list=()),
+            make_dynamic_fee_txn(access_list=()),
             True,
             id="valid_empty_dynamic_fee_access_list",
         ),
         pytest.param(
-            _make_blob_txn(access_list=()), True, id="valid_empty_blob_access_list"
+            make_blob_txn(access_list=()),
+            True,
+            id="valid_empty_blob_access_list",
         ),
         pytest.param(
-            _make_access_list_txn(
+            make_access_list_txn(
                 access_list=((b"\xf0" * 19, (0, 2)),),
             ),
             False,
             id="invalid_short_address_in_access_list",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(
+            make_dynamic_fee_txn(
                 access_list=((b"\xf0" * 19, ()),),
             ),
             False,
             id="invalid_short_address_with_empty_storage_keys",
         ),
         pytest.param(
-            _make_blob_txn(
+            make_blob_txn(
                 access_list=((b"\xf0" * 19, ()),),
             ),
             False,
             id="invalid_short_address_in_blob_access_list",
         ),
         pytest.param(
-            _make_access_list_txn(
+            make_access_list_txn(
                 access_list=((b"\xf0" * 20, ("0", 2)),),
             ),
             False,
             id="invalid_string_storage_key",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(
+            make_dynamic_fee_txn(
                 access_list=((b"\xf0" * 20, (b"", 1)),),
             ),
             False,
             id="invalid_empty_bytes_storage_key",
         ),
         pytest.param(
-            _make_blob_txn(
+            make_blob_txn(
                 access_list=((b"\xf0" * 20, (b"", 1)),),
             ),
             False,
             id="invalid_empty_bytes_storage_key_in_blob",
         ),
         pytest.param(
-            _make_dynamic_fee_txn(
+            make_dynamic_fee_txn(
                 access_list=(("", (1, 2)),),
             ),
             False,
             id="invalid_empty_string_address_in_access_list",
         ),
         pytest.param(
-            _make_blob_txn(
+            make_blob_txn(
                 access_list=(("", (1, 2)),),
             ),
             False,
@@ -573,7 +375,9 @@ def test_validate_outbound_transaction_hash(
         ),
         pytest.param({}, False, id="invalid_empty_dict"),
         pytest.param(
-            merge(_make_legacy_txn(), {"invalid-key": 1}), False, id="invalid_extra_key"
+            merge(make_legacy_txn(), {"invalid-key": 1}),
+            False,
+            id="invalid_extra_key",
         ),
     ),
 )
@@ -590,9 +394,9 @@ def test_transaction_output_validation(
 @pytest.mark.parametrize(
     "log_entry,is_valid",
     (
-        pytest.param(_make_log(), True, id="valid_standard_log"),
+        pytest.param(make_log(), True, id="valid_standard_log"),
         pytest.param(
-            _make_log(
+            make_log(
                 _type="pending",
                 transaction_index=None,
                 block_hash=None,
@@ -602,7 +406,7 @@ def test_transaction_output_validation(
             id="valid_pending_log",
         ),
         pytest.param(
-            _make_log(
+            make_log(
                 _type="mined",
                 transaction_index=None,
                 block_hash=None,
@@ -611,49 +415,47 @@ def test_transaction_output_validation(
             True,
             id="valid_mined_log_with_nulls",
         ),
-        pytest.param(_make_log(_type="invalid-type"), False, id="invalid_log_type"),
+        pytest.param(make_log(_type="invalid-type"), False, id="invalid_log_type"),
         pytest.param(
-            _make_log(transaction_index=-1),
+            make_log(transaction_index=-1),
             False,
             id="invalid_negative_transaction_index",
         ),
         pytest.param(
-            _make_log(block_number=-1), False, id="invalid_negative_block_number"
+            make_log(block_number=-1), False, id="invalid_negative_block_number"
         ),
         pytest.param(
-            _make_log(transaction_hash=HASH31),
+            make_log(transaction_hash=HASH31),
             False,
             id="invalid_short_transaction_hash",
         ),
         pytest.param(
-            _make_log(transaction_hash=HASH32_AS_TEXT),
+            make_log(transaction_hash=HASH32_AS_TEXT),
             False,
             id="invalid_text_transaction_hash",
         ),
+        pytest.param(make_log(block_hash=HASH31), False, id="invalid_short_block_hash"),
         pytest.param(
-            _make_log(block_hash=HASH31), False, id="invalid_short_block_hash"
+            make_log(block_hash=HASH32_AS_TEXT), False, id="invalid_text_block_hash"
         ),
         pytest.param(
-            _make_log(block_hash=HASH32_AS_TEXT), False, id="invalid_text_block_hash"
+            make_log(address=encode_hex(ADDRESS_A)), False, id="invalid_hex_address"
+        ),
+        pytest.param(make_log(data=""), False, id="invalid_empty_string_data"),
+        pytest.param(make_log(data=None), False, id="invalid_none_data"),
+        pytest.param(make_log(topics=[HASH32_AS_TEXT]), False, id="invalid_text_topic"),
+        pytest.param(make_log(topics=[HASH31]), False, id="invalid_short_topic"),
+        pytest.param(
+            make_log(topics=[TOPIC_A, TOPIC_B]), True, id="valid_multiple_topics"
         ),
         pytest.param(
-            _make_log(address=encode_hex(ADDRESS_A)), False, id="invalid_hex_address"
+            make_log(topics="invalid-topics"),  # type: ignore[arg-type]
+            False,
+            id="invalid_string_topics",
         ),
-        pytest.param(_make_log(data=""), False, id="invalid_empty_string_data"),
-        pytest.param(_make_log(data=None), False, id="invalid_none_data"),
+        pytest.param(make_log(address=ADDRESS_A), True, id="valid_address"),
         pytest.param(
-            _make_log(topics=[HASH32_AS_TEXT]), False, id="invalid_text_topic"
-        ),
-        pytest.param(_make_log(topics=[HASH31]), False, id="invalid_short_topic"),
-        pytest.param(
-            _make_log(topics=[TOPIC_A, TOPIC_B]), True, id="valid_multiple_topics"
-        ),
-        pytest.param(
-            _make_log(topics="invalid-topics"), False, id="invalid_string_topics"  # type: ignore[arg-type]
-        ),
-        pytest.param(_make_log(address=ADDRESS_A), True, id="valid_address"),
-        pytest.param(
-            merge(_make_log(), {"invalid-key": 1}), False, id="invalid_extra_key"
+            merge(make_log(), {"invalid-key": 1}), False, id="invalid_extra_key"
         ),
     ),
 )
@@ -739,9 +541,9 @@ def test_log_entry_output_validation(
             False,
             id="invalid_hex_contract_address",
         ),
-        pytest.param(make_receipt(logs=[_make_log()]), True, id="valid_logs"),
+        pytest.param(make_receipt(logs=[make_log()]), True, id="valid_logs"),
         pytest.param(
-            make_receipt(logs=[_make_log(_type="invalid")]),
+            make_receipt(logs=[make_log(_type="invalid")]),
             False,
             id="invalid_log_type_in_logs",
         ),
@@ -837,229 +639,231 @@ def test_receipt_output_validation(
 @pytest.mark.parametrize(
     "block,is_valid",
     (
-        pytest.param(_make_block(), True, id="valid_block"),
-        pytest.param(_make_block(number=-1), False, id="invalid_negative_number"),
-        pytest.param(_make_block(number=1.0), False, id="invalid_float_number"),
-        pytest.param(_make_block(number=True), False, id="invalid_bool_number"),
-        pytest.param(_make_block(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"),
-        pytest.param(_make_block(hash=HASH31), False, id="invalid_short_hash"),
+        pytest.param(make_block(), True, id="valid_block"),
+        pytest.param(make_block(number=-1), False, id="invalid_negative_number"),
+        pytest.param(make_block(number=1.0), False, id="invalid_float_number"),
+        pytest.param(make_block(number=True), False, id="invalid_bool_number"),
+        pytest.param(make_block(hash=HASH32_AS_TEXT), False, id="invalid_text_hash"),
+        pytest.param(make_block(hash=HASH31), False, id="invalid_short_hash"),
         pytest.param(
-            _make_block(parent_hash=HASH32_AS_TEXT),
+            make_block(parent_hash=HASH32_AS_TEXT),
             False,
             id="invalid_text_parent_hash",
         ),
         pytest.param(
-            _make_block(parent_hash=HASH31), False, id="invalid_short_parent_hash"
+            make_block(parent_hash=HASH31), False, id="invalid_short_parent_hash"
         ),
-        pytest.param(_make_block(nonce=-1), False, id="invalid_negative_nonce"),
-        pytest.param(_make_block(nonce=1.0), False, id="invalid_float_nonce"),
-        pytest.param(_make_block(nonce=True), False, id="invalid_bool_nonce"),
+        pytest.param(make_block(nonce=-1), False, id="invalid_negative_nonce"),
+        pytest.param(make_block(nonce=1.0), False, id="invalid_float_nonce"),
+        pytest.param(make_block(nonce=True), False, id="invalid_bool_nonce"),
         pytest.param(
-            _make_block(sha3_uncles=HASH32_AS_TEXT),
+            make_block(sha3_uncles=HASH32_AS_TEXT),
             False,
             id="invalid_text_sha3_uncles",
         ),
         pytest.param(
-            _make_block(logs_bloom=-1), False, id="invalid_negative_logs_bloom"
+            make_block(logs_bloom=-1), False, id="invalid_negative_logs_bloom"
         ),
-        pytest.param(_make_block(logs_bloom=1.0), False, id="invalid_float_logs_bloom"),
-        pytest.param(_make_block(logs_bloom=True), False, id="invalid_bool_logs_bloom"),
+        pytest.param(make_block(logs_bloom=1.0), False, id="invalid_float_logs_bloom"),
+        pytest.param(make_block(logs_bloom=True), False, id="invalid_bool_logs_bloom"),
         pytest.param(
-            _make_block(transactions_root=HASH32_AS_TEXT),
+            make_block(transactions_root=HASH32_AS_TEXT),
             False,
             id="invalid_text_transactions_root",
         ),
         pytest.param(
-            _make_block(transactions_root=HASH31),
+            make_block(transactions_root=HASH31),
             False,
             id="invalid_short_transactions_root",
         ),
         pytest.param(
-            _make_block(receipts_root=HASH32_AS_TEXT),
+            make_block(receipts_root=HASH32_AS_TEXT),
             False,
             id="invalid_text_receipts_root",
         ),
         pytest.param(
-            _make_block(receipts_root=HASH31), False, id="invalid_short_receipts_root"
+            make_block(receipts_root=HASH31), False, id="invalid_short_receipts_root"
         ),
         pytest.param(
-            _make_block(state_root=HASH32_AS_TEXT), False, id="invalid_text_state_root"
+            make_block(state_root=HASH32_AS_TEXT), False, id="invalid_text_state_root"
         ),
         pytest.param(
-            _make_block(state_root=HASH31), False, id="invalid_short_state_root"
+            make_block(state_root=HASH31), False, id="invalid_short_state_root"
         ),
         pytest.param(
-            _make_block(coinbase=encode_hex(ADDRESS_A)),
+            make_block(coinbase=encode_hex(ADDRESS_A)),
             False,
             id="invalid_hex_coinbase",
         ),
         pytest.param(
-            _make_block(difficulty=-1), False, id="invalid_negative_difficulty"
+            make_block(difficulty=-1), False, id="invalid_negative_difficulty"
         ),
-        pytest.param(_make_block(difficulty=1.0), False, id="invalid_float_difficulty"),
-        pytest.param(_make_block(difficulty=True), False, id="invalid_bool_difficulty"),
+        pytest.param(make_block(difficulty=1.0), False, id="invalid_float_difficulty"),
+        pytest.param(make_block(difficulty=True), False, id="invalid_bool_difficulty"),
         pytest.param(
-            _make_block(mix_hash=HASH32_AS_TEXT), False, id="invalid_text_mix_hash"
+            make_block(mix_hash=HASH32_AS_TEXT), False, id="invalid_text_mix_hash"
         ),
-        pytest.param(_make_block(mix_hash=HASH31), False, id="invalid_short_mix_hash"),
+        pytest.param(make_block(mix_hash=HASH31), False, id="invalid_short_mix_hash"),
         pytest.param(
-            _make_block(total_difficulty=-1),
+            make_block(total_difficulty=-1),
             False,
             id="invalid_negative_total_difficulty",
         ),
         pytest.param(
-            _make_block(total_difficulty=1.0),
+            make_block(total_difficulty=1.0),
             False,
             id="invalid_float_total_difficulty",
         ),
         pytest.param(
-            _make_block(total_difficulty=True),
+            make_block(total_difficulty=True),
             False,
             id="invalid_bool_total_difficulty",
         ),
-        pytest.param(_make_block(size=-1), False, id="invalid_negative_size"),
-        pytest.param(_make_block(size=1.0), False, id="invalid_float_size"),
-        pytest.param(_make_block(size=True), False, id="invalid_bool_size"),
+        pytest.param(make_block(size=-1), False, id="invalid_negative_size"),
+        pytest.param(make_block(size=1.0), False, id="invalid_float_size"),
+        pytest.param(make_block(size=True), False, id="invalid_bool_size"),
         pytest.param(
-            _make_block(extra_data=HASH32_AS_TEXT), False, id="invalid_text_extra_data"
+            make_block(extra_data=HASH32_AS_TEXT), False, id="invalid_text_extra_data"
         ),
         pytest.param(
-            _make_block(extra_data=HASH31), False, id="invalid_short_extra_data"
+            make_block(extra_data=HASH31), False, id="invalid_short_extra_data"
         ),
-        pytest.param(_make_block(gas_limit=-1), False, id="invalid_negative_gas_limit"),
-        pytest.param(_make_block(gas_limit=1.0), False, id="invalid_float_gas_limit"),
-        pytest.param(_make_block(gas_limit=True), False, id="invalid_bool_gas_limit"),
-        pytest.param(_make_block(gas_used=-1), False, id="invalid_negative_gas_used"),
-        pytest.param(_make_block(gas_used=1.0), False, id="invalid_float_gas_used"),
-        pytest.param(_make_block(gas_used=True), False, id="invalid_bool_gas_used"),
-        pytest.param(_make_block(timestamp=-1), False, id="invalid_negative_timestamp"),
-        pytest.param(_make_block(timestamp=1.0), False, id="invalid_float_timestamp"),
-        pytest.param(_make_block(timestamp=True), False, id="invalid_bool_timestamp"),
+        pytest.param(make_block(gas_limit=-1), False, id="invalid_negative_gas_limit"),
+        pytest.param(make_block(gas_limit=1.0), False, id="invalid_float_gas_limit"),
+        pytest.param(make_block(gas_limit=True), False, id="invalid_bool_gas_limit"),
+        pytest.param(make_block(gas_used=-1), False, id="invalid_negative_gas_used"),
+        pytest.param(make_block(gas_used=1.0), False, id="invalid_float_gas_used"),
+        pytest.param(make_block(gas_used=True), False, id="invalid_bool_gas_used"),
+        pytest.param(make_block(timestamp=-1), False, id="invalid_negative_timestamp"),
+        pytest.param(make_block(timestamp=1.0), False, id="invalid_float_timestamp"),
+        pytest.param(make_block(timestamp=True), False, id="invalid_bool_timestamp"),
         pytest.param(
-            _make_block(base_fee_per_gas=1000000000), True, id="valid_base_fee"
+            make_block(base_fee_per_gas=1000000000), True, id="valid_base_fee"
         ),
         pytest.param(
-            _make_block(base_fee_per_gas=-1000000000),
+            make_block(base_fee_per_gas=-1000000000),
             False,
             id="invalid_negative_base_fee",
         ),
         pytest.param(
-            _make_block(base_fee_per_gas=1000000000.0),
+            make_block(base_fee_per_gas=1000000000.0),
             False,
             id="invalid_float_base_fee",
         ),
         pytest.param(
-            _make_block(base_fee_per_gas="1000000000"),
+            make_block(base_fee_per_gas="1000000000"),
             False,
             id="invalid_string_base_fee",
         ),
-        pytest.param(_make_block(uncles=[ZERO_32BYTES]), True, id="valid_uncles"),
+        pytest.param(make_block(uncles=[ZERO_32BYTES]), True, id="valid_uncles"),
         pytest.param(
-            _make_block(uncles=[ZERO_32BYTES, HASH32_AS_TEXT]),
+            make_block(uncles=[ZERO_32BYTES, HASH32_AS_TEXT]),
             False,
             id="invalid_uncles_with_text",
         ),
-        pytest.param(_make_block(transactions="invalid"), False, id="valid_transactions_string"),  # type: ignore[arg-type]
         pytest.param(
-            _make_block(transactions=[ZERO_32BYTES]), True, id="valid_transactions_hash"
+            make_block(transactions="invalid"),  # type: ignore[arg-type]
+            False,
+            id="valid_transactions_string",
         ),
         pytest.param(
-            _make_block(transactions=[_make_legacy_txn()]),
+            make_block(transactions=[ZERO_32BYTES]), True, id="valid_transactions_hash"
+        ),
+        pytest.param(
+            make_block(transactions=[make_legacy_txn()]),
             True,
             id="valid_transactions_legacy_txn",
         ),
         pytest.param(
-            _make_block(transactions=[ZERO_32BYTES, _make_legacy_txn()]),
+            make_block(transactions=[ZERO_32BYTES, make_legacy_txn()]),
             False,
             id="invalid_mixed_transactions",
         ),
         pytest.param(
-            _make_block(transactions=[_make_access_list_txn()]),
+            make_block(transactions=[make_access_list_txn()]),
             True,
             id="valid_transactions_access_list",
         ),
         pytest.param(
-            _make_block(transactions=[ZERO_32BYTES, _make_access_list_txn()]),
+            make_block(transactions=[ZERO_32BYTES, make_access_list_txn()]),
             False,
             id="invalid_mixed_with_access_list",
         ),
         pytest.param(
-            _make_block(transactions=[_make_dynamic_fee_txn()]),
+            make_block(transactions=[make_dynamic_fee_txn()]),
             True,
             id="valid_transactions_dynamic_fee",
         ),
         pytest.param(
-            _make_block(transactions=[ZERO_32BYTES, _make_dynamic_fee_txn()]),
+            make_block(transactions=[ZERO_32BYTES, make_dynamic_fee_txn()]),
             False,
             id="invalid_mixed_with_dynamic_fee",
         ),
         pytest.param(
-            _make_block(transactions=[_make_blob_txn()]),
+            make_block(transactions=[make_blob_txn()]),
             True,
             id="valid_transactions_blob",
         ),
         pytest.param(
-            _make_block(transactions=[ZERO_32BYTES, _make_blob_txn()]),
+            make_block(transactions=[ZERO_32BYTES, make_blob_txn()]),
             False,
             id="invalid_mixed_with_blob",
         ),
         pytest.param(
-            _make_block(transactions=[ZERO_32BYTES, HASH32_AS_TEXT]),
+            make_block(transactions=[ZERO_32BYTES, HASH32_AS_TEXT]),
             False,
             id="invalid_transactions_with_text",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal()]), True, id="valid_withdrawals"
+            make_block(withdrawals=[make_withdrawal()]), True, id="valid_withdrawals"
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(address=ADDRESS_A)]),
+            make_block(withdrawals=[make_withdrawal(address=ADDRESS_A)]),
             True,
             id="valid_withdrawal_with_address",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(index=-1)]),
+            make_block(withdrawals=[make_withdrawal(index=-1)]),
             False,
             id="invalid_withdrawal_negative_index",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(index=2**64)]),
+            make_block(withdrawals=[make_withdrawal(index=2**64)]),
             False,
             id="invalid_withdrawal_index_too_large",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(validator_index=-1)]),
+            make_block(withdrawals=[make_withdrawal(validator_index=-1)]),
             False,
             id="invalid_withdrawal_negative_validator_index",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(validator_index=2**64)]),
+            make_block(withdrawals=[make_withdrawal(validator_index=2**64)]),
             False,
             id="invalid_withdrawal_validator_index_too_large",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(amount=-1)]),
+            make_block(withdrawals=[make_withdrawal(amount=-1)]),
             False,
             id="invalid_withdrawal_negative_amount",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(amount=2**64)]),
+            make_block(withdrawals=[make_withdrawal(amount=2**64)]),
             False,
             id="invalid_withdrawal_amount_too_large",
         ),
         pytest.param(
-            _make_block(withdrawals=[_make_withdrawal(address="1")]),
+            make_block(withdrawals=[make_withdrawal(address="1")]),
             False,
             id="invalid_withdrawal_string_address",
         ),
         pytest.param(
-            _make_block(
-                withdrawals=[_make_withdrawal(address=encode_hex(ZERO_ADDRESS))]
-            ),
+            make_block(withdrawals=[make_withdrawal(address=encode_hex(ZERO_ADDRESS))]),
             False,
             id="invalid_withdrawal_hex_address",
         ),
         pytest.param(
-            merge(_make_block(), {"invalid-key": 1}), False, id="invalid_extra_key"
+            merge(make_block(), {"invalid-key": 1}), False, id="invalid_extra_key"
         ),
     ),
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,52 +1,62 @@
+from typing import (
+    Any,
+    Iterator,
+    Tuple,
+)
+
 from eth_utils import (
     to_dict,
 )
 
-ZERO_32BYTES = b"\x00" * 32
-ZERO_ADDRESS = b"\x00" * 20
+from .constants import (
+    ZERO_32BYTES,
+    ZERO_ADDRESS,
+)
 
 
-def yield_key_value_if_value_not_none(key, value):
+def yield_key_value_if_value_not_none(
+    key: str, value: Any
+) -> Iterator[Tuple[str, Any]]:
     if value is not None:
         yield key, value
 
 
 @to_dict
 def make_receipt(
-    transaction_hash=ZERO_32BYTES,
-    transaction_index=0,
-    block_number=0,
-    block_hash=ZERO_32BYTES,
-    cumulative_gas_used=0,
-    blob_gas_used=None,
-    blob_gas_price=None,
-    _from=ZERO_ADDRESS,
-    gas_used=21000,
-    effective_gas_price=1000000000,
-    contract_address=ZERO_ADDRESS,
-    logs=None,
-    state_root=b"\x00",
-    status=0,
-    to=ZERO_ADDRESS,
-    _type="0x0",
-):
-    yield from yield_key_value_if_value_not_none("transaction_hash", transaction_hash)
-    yield from yield_key_value_if_value_not_none("transaction_index", transaction_index)
-    yield from yield_key_value_if_value_not_none("block_number", block_number)
-    yield from yield_key_value_if_value_not_none("block_hash", block_hash)
+    transaction_hash: Any = ZERO_32BYTES,
+    transaction_index: Any = 0,
+    block_number: Any = 0,
+    block_hash: Any = ZERO_32BYTES,
+    cumulative_gas_used: Any = 0,
+    blob_gas_used: Any = None,
+    blob_gas_price: Any = None,
+    _from: Any = ZERO_ADDRESS,
+    gas_used: Any = 21000,
+    effective_gas_price: Any = 1000000000,
+    contract_address: Any = ZERO_ADDRESS,
+    logs: Any = None,
+    state_root: Any = b"\x00",
+    status: Any = 0,
+    to: Any = ZERO_ADDRESS,
+    _type: Any = "0x0",
+) -> Iterator[Tuple[str, Any]]:
+    yield from yield_key_value_if_value_not_none("transactionHash", transaction_hash)
+    yield from yield_key_value_if_value_not_none("transactionIndex", transaction_index)
+    yield from yield_key_value_if_value_not_none("blockNumber", block_number)
+    yield from yield_key_value_if_value_not_none("blockHash", block_hash)
     yield from yield_key_value_if_value_not_none(
-        "cumulative_gas_used", cumulative_gas_used
+        "cumulativeGasUsed", cumulative_gas_used
     )
-    yield from yield_key_value_if_value_not_none("gas_used", gas_used)
+    yield from yield_key_value_if_value_not_none("gasUsed", gas_used)
     yield from yield_key_value_if_value_not_none(
-        "effective_gas_price", effective_gas_price
+        "effectiveGasPrice", effective_gas_price
     )
     yield from yield_key_value_if_value_not_none("from", _from)
     yield from yield_key_value_if_value_not_none("to", to)
     yield from yield_key_value_if_value_not_none("type", _type)
-    yield from yield_key_value_if_value_not_none("state_root", state_root)
+    yield from yield_key_value_if_value_not_none("stateRoot", state_root)
     yield from yield_key_value_if_value_not_none("status", status)
     yield from yield_key_value_if_value_not_none("logs", logs or [])
-    yield from yield_key_value_if_value_not_none("contract_address", contract_address)
-    yield from yield_key_value_if_value_not_none("blob_gas_used", blob_gas_used)
-    yield from yield_key_value_if_value_not_none("blob_gas_price", blob_gas_price)
+    yield from yield_key_value_if_value_not_none("contractAddress", contract_address)
+    yield from yield_key_value_if_value_not_none("blobGasUsed", blob_gas_used)
+    yield from yield_key_value_if_value_not_none("blobGasPrice", blob_gas_price)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,14 +1,29 @@
 from typing import (
     Any,
+    Dict,
     Iterator,
+    List,
+    Optional,
     Tuple,
 )
 
 from eth_utils import (
     to_dict,
 )
+from toolz import (
+    dissoc,
+    merge,
+)
 
-from .constants import (
+from eth_tester.constants import (
+    ACCESS_LIST_TX_TYPE,
+    BLOB_TX_TYPE,
+    DYNAMIC_FEE_TX_TYPE,
+    LEGACY_TX_TYPE,
+)
+from tests.constants import (
+    DEFAULT_GAS_LIMIT,
+    ZERO_8BYTES,
     ZERO_32BYTES,
     ZERO_ADDRESS,
 )
@@ -19,6 +34,220 @@ def yield_key_value_if_value_not_none(
 ) -> Iterator[Tuple[str, Any]]:
     if value is not None:
         yield key, value
+
+
+def make_legacy_txn(
+    hash: Any = ZERO_32BYTES,
+    nonce: Any = 0,
+    block_hash: Optional[Any] = ZERO_32BYTES,
+    block_number: Optional[Any] = 0,
+    transaction_index: Optional[int] = 0,
+    _from: Any = ZERO_ADDRESS,
+    to: Any = ZERO_ADDRESS,
+    value: Any = 0,
+    gas: Any = DEFAULT_GAS_LIMIT,
+    gas_price: Any = 1,
+    data: Any = b"",
+    v: Any = 0,
+    r: Any = 0,
+    s: Any = 0,
+) -> Dict[str, Any]:
+    return {
+        "type": LEGACY_TX_TYPE,
+        "hash": hash,
+        "nonce": nonce,
+        "blockHash": block_hash,
+        "blockNumber": block_number,
+        "transactionIndex": transaction_index,
+        "from": _from,
+        "to": to,
+        "value": value,
+        "gas": gas,
+        "gasPrice": gas_price,
+        "data": data,
+        "s": s,
+        "r": r,
+        "v": v,
+    }
+
+
+def make_access_list_txn(
+    chain_id: Any = 131277322940537,
+    access_list: Tuple[Any, ...] = (),
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    legacy_kwargs = dissoc(dict(**kwargs), "chain_id", "access_list")
+    return dict(
+        merge(
+            make_legacy_txn(**legacy_kwargs),
+            {
+                "type": ACCESS_LIST_TX_TYPE,
+                "chainId": chain_id,
+                "accessList": list(access_list),
+                "yParity": legacy_kwargs.get("v", 0),
+            },
+        )
+    )
+
+
+# This is an outbound transaction so we still keep the gas_price for now since the
+# gas_price is the min(max_fee_per_gas, base_fee_per_gas + max_priority_fee_per_gas).
+# TODO: Sometime in 2022 the inclusion of gas_price may be removed from dynamic fee
+#  transactions and we can get rid of this behavior.
+#  https://github.com/ethereum/execution-specs/pull/251
+def make_dynamic_fee_txn(
+    chain_id: Any = 131277322940537,
+    max_fee_per_gas: Any = 2000000000,
+    max_priority_fee_per_gas: Any = 1000000000,
+    access_list: Tuple[Any, ...] = (),
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    legacy_kwargs = dissoc(
+        dict(**kwargs),
+        "chainId",
+        "maxFeePerGas",
+        "maxPriorityFeePerGas",
+        "accessList",
+    )
+    return dict(
+        merge(
+            make_access_list_txn(
+                chain_id=chain_id, access_list=access_list, **legacy_kwargs
+            ),
+            {
+                "type": DYNAMIC_FEE_TX_TYPE,
+                "maxFeePerGas": max_fee_per_gas,
+                "maxPriorityFeePerGas": max_priority_fee_per_gas,
+            },
+        )
+    )
+
+
+def make_blob_txn(
+    chain_id: Any = 131277322940537,
+    max_fee_per_gas: Any = 2000000000,
+    max_priority_fee_per_gas: Any = 1000000000,
+    access_list: Tuple[Any, ...] = (),
+    max_fee_per_blob_gas: Any = 1000000000,
+    blob_versioned_hashes: Tuple[Any, ...] = (),
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    legacy_kwargs = dissoc(
+        dict(**kwargs),
+        "chainId",
+        "maxFeePerGas",
+        "maxPriorityFeePerGas",
+        "accessList",
+        "maxFeePerBlobGas",
+        "blobVersionedHashes",
+    )
+    return dict(
+        merge(
+            make_dynamic_fee_txn(
+                chain_id=chain_id,
+                access_list=access_list,
+                max_fee_per_gas=max_fee_per_gas,
+                max_priority_fee_per_gas=max_priority_fee_per_gas,
+                **legacy_kwargs,
+            ),
+            {
+                "type": BLOB_TX_TYPE,
+                "maxFeePerBlobGas": max_fee_per_blob_gas,
+                "blobVersionedHashes": list(blob_versioned_hashes),
+            },
+        )
+    )
+
+
+def make_log(
+    _type: Any = "mined",
+    log_index: Any = 0,
+    transaction_index: Any = 0,
+    transaction_hash: Any = ZERO_32BYTES,
+    block_hash: Any = ZERO_32BYTES,
+    block_number: Any = 0,
+    address: Any = ZERO_ADDRESS,
+    data: Any = b"",
+    topics: Optional[List[Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "type": _type,
+        "logIndex": log_index,
+        "transactionIndex": transaction_index,
+        "transactionHash": transaction_hash,
+        "blockHash": block_hash,
+        "blockNumber": block_number,
+        "address": address,
+        "data": data,
+        "topics": topics or [],
+    }
+
+
+def make_block(
+    number: Any = 0,
+    hash: Any = ZERO_32BYTES,
+    parent_hash: Any = ZERO_32BYTES,
+    nonce: Any = ZERO_8BYTES,
+    sha3_uncles: Any = ZERO_32BYTES,
+    logs_bloom: Any = 0,
+    transactions_root: Any = ZERO_32BYTES,
+    receipts_root: Any = ZERO_32BYTES,
+    state_root: Any = ZERO_32BYTES,
+    coinbase: Any = ZERO_ADDRESS,
+    difficulty: Any = 0,
+    mix_hash: Any = ZERO_32BYTES,
+    total_difficulty: Any = 0,
+    size: Any = 0,
+    extra_data: Any = ZERO_32BYTES,
+    gas_limit: Any = 30029122,  # gas limit at London fork block 12965000 on mainnet
+    gas_used: Any = 21000,
+    timestamp: Any = 4000000,
+    transactions: Optional[List[Any]] = None,
+    uncles: Optional[List[Any]] = None,
+    base_fee_per_gas: Any = 1000000000,
+    withdrawals: Optional[List[Any]] = None,
+    withdrawals_root: Any = ZERO_32BYTES,
+) -> Dict[str, Any]:
+    block = {
+        "number": number,
+        "hash": hash,
+        "parentHash": parent_hash,
+        "nonce": nonce,
+        "sha3Uncles": sha3_uncles,
+        "logsBloom": logs_bloom,
+        "transactionsRoot": transactions_root,
+        "receiptsRoot": receipts_root,
+        "stateRoot": state_root,
+        "coinbase": coinbase,
+        "difficulty": difficulty,
+        "mixHash": mix_hash,
+        "totalDifficulty": total_difficulty,
+        "size": size,
+        "extraData": extra_data,
+        "gasLimit": gas_limit,
+        "gasUsed": gas_used,
+        "timestamp": timestamp,
+        "transactions": transactions or [],
+        "uncles": uncles or [],
+        "baseFeePerGas": base_fee_per_gas,
+        "withdrawals": withdrawals or [],
+        "withdrawalsRoot": withdrawals_root,
+    }
+    return block
+
+
+def make_withdrawal(
+    index: Any = 2**64 - 1,
+    validator_index: Any = 2**64 - 1,
+    address: Any = ZERO_ADDRESS,
+    amount: Any = 2**64 - 1,
+) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "validatorIndex": validator_index,
+        "address": address,
+        "amount": amount,
+    }
 
 
 @to_dict

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist=
     py{38,39,310,311,312,313}-lint
     py{38,39,310,311,312,313}-wheel
     py{38,39,310,311,312,313}-pyevm
-    py{38,39,310,311,312,313}-eels
+    # eels only supported on Python 3.10+
+    py{310,311,312,313}-eels
     windows-wheel
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py{38,39,310,311,312,313}-lint
     py{38,39,310,311,312,313}-wheel
     py{38,39,310,311,312,313}-pyevm
+    py{38,39,310,311,312,313}-eels
     windows-wheel
     docs
 
@@ -20,7 +21,8 @@ max_issue_threshold=1
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
-    pyevm: pytest {posargs:tests/backends/test_pyevm.py}
+    pyevm: pytest {posargs:tests/backends/pyevm}
+    eels: pytest {posargs:tests/backends/eels}
     docs: make docs
 deps =
     coincurve>=6.0.0
@@ -37,6 +39,7 @@ extras=
     test
     docs
     pyevm: py-evm
+    eels: eels
 allowlist_externals=make,pre-commit
 
 [testenv:py{38,39,310,311,312,313}-lint]


### PR DESCRIPTION
### What was wrong?

Closes #321
Closes #322

### How was it fixed?
Outbound serializers, validators and normalizers have been updated to expect all dicts to have camel case keys.

### Todo:

- [X] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s1.r29static.com/bin/entry/37b/x/1454601/image.jpg)
