### PR TITLE
fix: wrong `venv.create` mention

### DIFF
--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -10,7 +10,7 @@ import venv
 
 def create_venv(parent_path: Path) -> Path:
     venv_path = parent_path / "package-smoke-test"
-    venv.create(venv_path, with_pip=True)
+    venv.EnvBuilder(with_pip=True).create(venv_path)
     subprocess.run(
         [venv_path / "bin" / "pip", "install", "-U", "pip", "setuptools"], check=True
     )


### PR DESCRIPTION
### What was wrong?

the docs mentioned `venv.create`, which doesn’t exist. switched it to the correct usage - should be all good now.


### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute](https://listproducer.com/wp-content/uploads/2014/10/cute.jpg)
