### PR TITLE
Update the copyright year to 2026 in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2025 The Ethereum Foundation
+Copyright (c) 2017-2026 The Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### What was wrong?

Update the copyright year to 2026 in LICENSE

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://private-user-images.githubusercontent.com/170858334/339036506-5cf316ae-0987-4a0b-a22f-3f2b978ae378.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njc4Mzk0MDksIm5iZiI6MTc2NzgzOTEwOSwicGF0aCI6Ii8xNzA4NTgzMzQvMzM5MDM2NTA2LTVjZjMxNmFlLTA5ODctNGEwYi1hMjJmLTNmMmI5NzhhZTM3OC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMTA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDEwOFQwMjI1MDlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02MDhjOTY4NzM2YzJkZDYxNWVmYzQ4ZTE1NTJiZDgyNGM1YTY4OGM2M2UyNWY0NzI3YmY1MzQ0MmZmMzkxZGIwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.E1kR5eusf6KlIxsJzaTsW4JPr1EC4f28FiC3_WXOMmE)
